### PR TITLE
Pool git-worktree sessions under one project in cc-explorer

### DIFF
--- a/project-mining/.claude-plugin/plugin.json
+++ b/project-mining/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-mining",
-  "version": "2.22.1",
+  "version": "2.23.0",
   "description": "Mine project histories for behavioral evidence. Search chat logs, git history, docs, and code for concrete examples of specific patterns, values, or skills.",
   "author": {
     "name": "Cory King",

--- a/project-mining/agents/mining-researcher.md
+++ b/project-mining/agents/mining-researcher.md
@@ -94,6 +94,13 @@ The `session:xxx/turn:yyy` references are stable — they point to the immutable
 JSONL entry, not a line number in a derived file. Use them in your findings'
 Source field.
 
+**Worktree-labeled sessions.** Every session carries a `worktree` field. Absent means the session happened in the project's main worktree; set (e.g. `happy-lehmann`) means a linked git worktree — typically a Claude Desktop dispatched session under `.claude-worktrees/`. Calibrate signal:
+
+- **Dispatched sessions are weaker "user's own words" evidence.** The "user" turn may be a programmatically-constructed prompt, not something someone typed in frustration. Don't mistake it for authentic in-the-moment voice.
+- **Dispatched sessions are stronger "agent autonomy" evidence.** They show what the agent decided on its own, how it interpreted an ambiguous brief, what it chose to do without a human steering mid-flight.
+- **The worktree name is a git branch bridge.** `happy-lehmann` in metadata → look at commits on the `happy-lehmann` branch to cross-reference chat evidence with the code that actually landed.
+- **Parallel fan-out is architectural evidence.** Multiple worktrees active in the same timeframe = deliberate parallelism, a real decision worth noting in findings.
+
 ## Tool Access
 
 The cc-explorer MCP tools are automatically available to named agents within this plugin. The tool descriptions document parameters, output format, and usage — refer to them for mechanics.

--- a/project-mining/pyproject.toml
+++ b/project-mining/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-explorer"
-version = "1.22.1"
+version = "1.23.0"
 description = "MCP server for exploring Claude Code chat history — search conversations, quote moments, inspect subagents."
 requires-python = ">=3.11"
 dependencies = [

--- a/project-mining/skills/cc-explorer/SKILL.md
+++ b/project-mining/skills/cc-explorer/SKILL.md
@@ -51,6 +51,14 @@ Tools for tracing subagent execution — a separate axis from conversation conte
 
 Use when tracing what an agent did, correlating outputs with sessions, or building timelines that distinguish "discussed doing X" from "dispatched agents to do X."
 
+## Worktree pooling
+
+Sessions from every git worktree of a project are pooled under one project. Claude Desktop dispatch creates real git worktrees under `<project>/.claude-worktrees/<name>/`, so dispatched work shows up alongside interactive sessions automatically — no need to specify a worktree or know which branch work happened on.
+
+Each session carries a `worktree` field: absent for the main worktree, set to the worktree's directory basename (e.g. `happy-lehmann`) for linked worktrees. `list_project_sessions`, `grep_session`, `read_turn`, `browse_session`, `list_session_agents`, `get_agent_detail`, and `session_tool_audit` all surface it.
+
+**Why it matters for mining:** labeled sessions are usually dispatch-driven, meaning the "user" turn is often a programmatically-constructed prompt, not a human typing in-the-moment. Weight signal accordingly — dispatch sessions are weaker evidence for "user's own words" but stronger evidence for "what the agent decided autonomously." The worktree label also doubles as a git branch bridge: `happy-lehmann` in the session metadata points you at the `happy-lehmann` branch when cross-referencing with git history.
+
 ## When to use what
 
 **"What conversations exist?"** → `list_project_sessions`. Stats (message count, agent count, dates) help you decide where to look.

--- a/project-mining/src/cc_explorer/mcp_server.py
+++ b/project-mining/src/cc_explorer/mcp_server.py
@@ -318,6 +318,7 @@ def grep_session(
         results=pattern_results,
         truncate=truncate,
         hide=hide_set,
+        worktree=sessions[0].worktree,
     )
 
 
@@ -427,6 +428,7 @@ def grep_sessions(
                 results=pattern_results,
                 truncate=truncate,
                 hide=hide_set,
+                worktree=sess.worktree,
             )
         )
 
@@ -616,6 +618,7 @@ def browse_session(
         truncate=truncate,
         anchor=turn,
         hide=hide_set,
+        worktree=target[0].worktree,
     )
 
 
@@ -873,6 +876,7 @@ def session_tool_audit(
 
     return SessionToolAuditResponse(
         session=PrefixId(target.session_id),
+        worktree=target.worktree,
         title=target.title,
         total_dispatched=total_dispatched,
         total_audited=len(audits),

--- a/project-mining/src/cc_explorer/parser.py
+++ b/project-mining/src/cc_explorer/parser.py
@@ -4,14 +4,15 @@
 
 Core functions:
 - load_transcript(path) — parse a JSONL file into typed entries
-- load_conversations(project_path) — find all JSONL files for a project
+- load_conversations(project_path) — find all JSONL files for a project,
+  pooled across git worktrees
 - extract_text — re-exported from models.py
 """
 
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Sequence, Union, cast
+from typing import Any, Optional, Sequence, Union, cast
 
 from pydantic import BaseModel
 
@@ -239,29 +240,76 @@ def load_transcript(path: Path) -> list[TranscriptEntry]:
     return entries
 
 
-def load_conversations(project_path: str) -> dict[PrefixId, Path]:
-    """Find all JSONL conversation files for a project.
+@dataclass(frozen=True)
+class ConversationRef:
+    """A located JSONL conversation, plus which worktree it came from.
 
-    Returns {session_id: path} mapping where session_id is the UUID
-    from the filename (without .jsonl extension).
-
-    Uses the Claude Agent SDK for path resolution — handles long paths
-    with hash suffixes, Bun/Node hash mismatches, CLAUDE_CONFIG_DIR,
-    and git worktree scanning.
+    `worktree=None` means the session belongs to the main worktree of the
+    project (the one `git worktree list` reports first — the repo root).
+    `worktree="<name>"` is the basename of a linked worktree directory
+    (e.g. `"happy-lehmann"` for `<project>/.claude-worktrees/happy-lehmann`).
+    Claude Desktop dispatch creates these as real git worktrees, so they
+    appear in `git worktree list` automatically.
     """
-    from claude_agent_sdk._internal.sessions import _canonicalize_path, _find_project_dir
+
+    path: Path
+    worktree: Optional[str]
+
+
+def load_conversations(project_path: str) -> dict[PrefixId, ConversationRef]:
+    """Find all JSONL conversation files for a project, pooled across worktrees.
+
+    Returns {session_id: ConversationRef} where session_id is the UUID from
+    the filename. Sessions from every git worktree of the project are merged
+    into one pool — the main worktree gets `worktree=None`, linked worktrees
+    get labeled with their directory basename.
+
+    Uses the Claude Agent SDK for path resolution (handles long-path hash
+    suffixes, Bun/Node hash mismatches, CLAUDE_CONFIG_DIR) and for the
+    `git worktree list --porcelain` shell-out that discovers worktree paths.
+
+    When git is unavailable or `project_path` is not inside a repo, falls
+    back to scanning the single project directory (all sessions get
+    `worktree=None`).
+    """
+    from claude_agent_sdk._internal.sessions import (
+        _canonicalize_path,
+        _find_project_dir,
+        _get_worktree_paths,
+    )
 
     project_path_resolved = str(Path(project_path).expanduser().resolve())
     canonical = _canonicalize_path(project_path_resolved)
-    claude_dir = _find_project_dir(canonical)
 
-    if claude_dir is None or not claude_dir.exists():
-        return {}
+    # Worktree paths from `git worktree list --porcelain`. The main worktree
+    # is always first in git's output — we use that ordering to decide which
+    # sessions are "main" (worktree=None) vs labeled.
+    worktree_paths = _get_worktree_paths(canonical)
 
-    result: dict[PrefixId, Path] = {}
-    for jsonl_path in claude_dir.glob("*.jsonl"):
-        session_id = PrefixId(jsonl_path.stem)
-        result[session_id] = jsonl_path
+    # Fallback: no git / not a repo / scan failed → single-dir behavior.
+    if not worktree_paths:
+        claude_dir = _find_project_dir(canonical)
+        if claude_dir is None or not claude_dir.exists():
+            return {}
+        return {
+            PrefixId(jsonl.stem): ConversationRef(path=jsonl, worktree=None)
+            for jsonl in claude_dir.glob("*.jsonl")
+        }
+
+    result: dict[PrefixId, ConversationRef] = {}
+    for i, wt_path in enumerate(worktree_paths):
+        claude_dir = _find_project_dir(wt_path)
+        if claude_dir is None or not claude_dir.exists():
+            continue
+        label: Optional[str] = None if i == 0 else Path(wt_path).name
+        for jsonl in claude_dir.glob("*.jsonl"):
+            session_id = PrefixId(jsonl.stem)
+            # First-wins on dupes. A session UUID should only exist in one
+            # worktree's project dir, but if the same file somehow appears
+            # in multiple (shared cache, weird symlink), keep the earlier
+            # one — main worktree (i=0) takes priority by construction.
+            if session_id not in result:
+                result[session_id] = ConversationRef(path=jsonl, worktree=label)
     return result
 
 

--- a/project-mining/src/cc_explorer/responses.py
+++ b/project-mining/src/cc_explorer/responses.py
@@ -49,6 +49,10 @@ class SessionSummary(SparseModel):
     session: PrefixId = Field(description="Session identifier — pass this back as the `session` param to other tools.")
     date: datetime | None = Field(default=None, description="Timestamp of first message.")
     title: str | None = Field(default=None, description="Auto-generated title from first human message.")
+    worktree: str | None = Field(
+        default=None,
+        description="Git worktree name this session lived in. Absent for the main worktree; present (e.g. 'happy-lehmann') for linked worktrees, which includes Claude Desktop dispatched sessions under `.claude-worktrees/`. Labeled sessions are often programmatically dispatched rather than interactively typed — calibrate signal accordingly.",
+    )
     messages: int = Field(description="Total message count.")
     agents: int = Field(description="Number of subagent dispatches.")
     context_tokens: int = Field(description="Last assistant turn's input tokens (context window size).")
@@ -61,6 +65,7 @@ class SessionSummary(SparseModel):
             session=s.session_id,
             date=s.first_timestamp,
             title=s.title,
+            worktree=s.worktree,
             messages=s.message_count,
             agents=s.stats.agent_count,
             context_tokens=s.stats.context_tokens,
@@ -204,6 +209,10 @@ class GrepSessionResponse(SparseModel):
     """
 
     session: PrefixId = Field(description="Session identifier.")
+    worktree: str | None = Field(
+        default=None,
+        description="Git worktree name this session lived in, if not the main one. Labeled sessions are often dispatch-driven rather than interactively typed.",
+    )
     patterns: list[GrepPatternResult] = Field(
         description="Per-pattern results, sorted by hit count descending.",
     )
@@ -215,6 +224,7 @@ class GrepSessionResponse(SparseModel):
         results: list[tuple[str, list[MatchHit], int]],
         truncate: int,
         hide: frozenset[str] = frozenset(),
+        worktree: str | None = None,
     ) -> GrepSessionResponse:
         """Build response from a list of (pattern, matches, total_hits) tuples."""
 
@@ -251,7 +261,11 @@ class GrepSessionResponse(SparseModel):
             )
 
         pattern_results.sort(key=lambda p: p.hits, reverse=True)
-        return cls(session=PrefixId(session_id), patterns=pattern_results)
+        return cls(
+            session=PrefixId(session_id),
+            worktree=worktree,
+            patterns=pattern_results,
+        )
 
 
 class GrepSessionsResponse(SparseModel):
@@ -282,6 +296,10 @@ class ReadTurnResponse(SparseModel):
     """A specific moment in a conversation at full fidelity."""
 
     session: PrefixId | None = Field(default=None, description="Session identifier.")
+    worktree: str | None = Field(
+        default=None,
+        description="Git worktree name this session lived in, if not the main one.",
+    )
     turn: PrefixId = Field(description="Turn identifier.")
     chats: list[str] = Field(
         description="Pipe-delimited entry lines: turn_id|timestamp|role|full_length|display. Full untruncated text unless truncate was set.",
@@ -301,6 +319,7 @@ class ReadTurnResponse(SparseModel):
 
         return cls(
             session=PrefixId(session_info.session_id) if session_info else None,
+            worktree=session_info.worktree if session_info else None,
             turn=PrefixId(turn),
             chats=chats,
         )
@@ -315,6 +334,10 @@ class BrowseSessionResponse(SparseModel):
     """First or last N conversation turns from a session."""
 
     session: PrefixId = Field(description="Session identifier.")
+    worktree: str | None = Field(
+        default=None,
+        description="Git worktree name this session lived in, if not the main one.",
+    )
     position: str = Field(description="'head' or 'tail' — which end was read.")
     showing: int = Field(description="Number of turns returned.")
     total_turns: int = Field(description="Total conversation turns in the session.")
@@ -333,10 +356,12 @@ class BrowseSessionResponse(SparseModel):
         truncate: int,
         anchor: str | None = None,
         hide: frozenset[str] = frozenset(),
+        worktree: str | None = None,
     ) -> BrowseSessionResponse:
         chats = [format_entry_line(e, truncate=truncate, hide=hide) for e in entries]
         return cls(
             session=PrefixId(session_id),
+            worktree=worktree,
             position=position,
             showing=len(entries),
             total_turns=total,
@@ -384,6 +409,10 @@ class SessionAgentsResponse(SparseModel):
     """All agents spawned by a specific session."""
 
     session: PrefixId = Field(description="Session identifier.")
+    worktree: str | None = Field(
+        default=None,
+        description="Git worktree name this session lived in, if not the main one.",
+    )
     date: datetime | None = Field(default=None, description="Timestamp of session start.")
     title: str | None = Field(default=None, description="Session title.")
     total_agents: int = Field(description="Number of agents in this session.")
@@ -397,6 +426,7 @@ class SessionAgentsResponse(SparseModel):
     ) -> SessionAgentsResponse:
         return cls(
             session=target.session_id,
+            worktree=target.worktree,
             date=target.first_timestamp,
             title=target.title,
             total_agents=len(agents),
@@ -422,6 +452,10 @@ class AgentDetailResponse(SparseModel):
     """Full detail for a single agent: prompt, result, stats, optional trace."""
 
     session: PrefixId = Field(description="Parent session identifier.")
+    worktree: str | None = Field(
+        default=None,
+        description="Git worktree name the parent session lived in, if not the main one.",
+    )
     date: datetime | None = Field(default=None, description="Timestamp of session start.")
     title: str | None = Field(default=None, description="Session title.")
     agent_id: PrefixId = Field(description="Agent identifier.")
@@ -473,6 +507,7 @@ class AgentDetailResponse(SparseModel):
 
         return cls(
             session=found_session.session_id,
+            worktree=found_session.worktree,
             date=found_session.first_timestamp,
             title=found_session.title,
             agent_id=found.agent_id,
@@ -538,6 +573,10 @@ class SessionToolAuditResponse(SparseModel):
     """
 
     session: PrefixId = Field(description="Session identifier.")
+    worktree: str | None = Field(
+        default=None,
+        description="Git worktree name this session lived in, if not the main one.",
+    )
     title: str | None = Field(default=None, description="Session title.")
     total_dispatched: int = Field(
         description="Number of subagents the session spawned, regardless of whether their output files were accessible. This is the truth about how much fan-out happened."

--- a/project-mining/src/cc_explorer/search.py
+++ b/project-mining/src/cc_explorer/search.py
@@ -113,7 +113,13 @@ def extract_tool_text(entry: AssistantTranscriptEntry) -> str:
 
 @dataclass
 class SessionInfo:
-    """Metadata about a conversation session."""
+    """Metadata about a conversation session.
+
+    `worktree` is the git worktree name the session lived in, or None for
+    the project's main worktree. Claude Desktop dispatch creates linked
+    worktrees under `<project>/.claude-worktrees/<name>/`, so dispatched
+    sessions come back labeled with their basename (e.g. 'happy-lehmann').
+    """
 
     session_id: PrefixId
     path: Path
@@ -121,6 +127,7 @@ class SessionInfo:
     first_timestamp: Optional[datetime]
     message_count: int
     stats: TranscriptStats = field(default_factory=TranscriptStats)
+    worktree: Optional[str] = None
 
 
 @dataclass
@@ -223,8 +230,8 @@ def load_sessions(project_path: str) -> list[SessionInfo]:
     conversations = load_conversations(project_path)
     sessions: list[SessionInfo] = []
 
-    for session_id, path in conversations.items():
-        entries = load_transcript(path)
+    for session_id, ref in conversations.items():
+        entries = load_transcript(ref.path)
         if not entries:
             continue
 
@@ -250,11 +257,12 @@ def load_sessions(project_path: str) -> list[SessionInfo]:
         sessions.append(
             SessionInfo(
                 session_id=session_id,
-                path=path,
+                path=ref.path,
                 title=title,
                 first_timestamp=first_ts,
                 message_count=message_count,
                 stats=stats,
+                worktree=ref.worktree,
             )
         )
 

--- a/project-mining/tests/test_empty_sessions.py
+++ b/project-mining/tests/test_empty_sessions.py
@@ -20,6 +20,7 @@ from cc_explorer.models import (
     TranscriptStats,
     UserMessageModel,
 )
+from cc_explorer.parser import ConversationRef
 from cc_explorer.search import load_sessions
 
 
@@ -58,7 +59,10 @@ def _assistant(text: str = "", uuid: str = "22222222-aaaa-bbbb-cccc-dddddddddddd
 
 def _patch_conversations_and_transcripts(sessions: dict[str, list]):
     """Patch both load_conversations and load_transcript."""
-    conversations = {sid: Path(f"{sid}.jsonl") for sid in sessions}
+    conversations = {
+        sid: ConversationRef(path=Path(f"{sid}.jsonl"), worktree=None)
+        for sid in sessions
+    }
 
     def _load_transcript(path):
         sid = path.stem

--- a/project-mining/tests/test_worktree_unification.py
+++ b/project-mining/tests/test_worktree_unification.py
@@ -1,0 +1,148 @@
+"""Tests for git-worktree-aware conversation loading.
+
+Claude Desktop dispatch creates real git worktrees under
+`<project>/.claude-worktrees/<name>/`. Every worktree of a project gets
+its own sanitized dir in `~/.claude/projects/`, and sessions from
+dispatched work would be silently invisible if `load_conversations`
+only scanned the main worktree's dir.
+
+These tests patch the Agent-SDK helpers (_get_worktree_paths,
+_find_project_dir) so the parser's behavior can be verified without
+spinning up a real git repo + worktrees.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cc_explorer.parser import ConversationRef, load_conversations
+
+
+class _FakeDir:
+    """Stand-in for a Path that supports .glob() and .exists() only."""
+
+    def __init__(self, jsonls: list[str]):
+        self._jsonls = [Path(j) for j in jsonls]
+
+    def exists(self) -> bool:
+        return True
+
+    def glob(self, pattern: str):
+        assert pattern == "*.jsonl"
+        return iter(self._jsonls)
+
+
+def _patch(worktree_paths, find_map):
+    """Patch SDK helpers inside the parser module's local import."""
+    import claude_agent_sdk._internal.sessions as sdk
+
+    return [
+        patch.object(sdk, "_get_worktree_paths", return_value=worktree_paths),
+        patch.object(
+            sdk, "_find_project_dir", side_effect=lambda p: find_map.get(p)
+        ),
+        patch.object(
+            sdk, "_canonicalize_path", side_effect=lambda p: p
+        ),
+    ]
+
+
+class TestWorktreePooling:
+
+    def test_no_git_falls_back_to_single_dir(self):
+        """Empty worktree list → single-dir scan, all sessions get worktree=None."""
+        fake = _FakeDir(["/claude/-proj/aaaa1111.jsonl", "/claude/-proj/bbbb2222.jsonl"])
+        patches = _patch(
+            worktree_paths=[],
+            find_map={"/home/me/proj": fake},
+        )
+        with patches[0], patches[1], patches[2]:
+            result = load_conversations("/home/me/proj")
+
+        assert len(result) == 2
+        for ref in result.values():
+            assert isinstance(ref, ConversationRef)
+            assert ref.worktree is None
+
+    def test_main_worktree_only(self):
+        """Single worktree returned (main only) → sessions are unlabeled."""
+        fake = _FakeDir(["/claude/-proj/aaaa1111.jsonl"])
+        patches = _patch(
+            worktree_paths=["/home/me/proj"],
+            find_map={"/home/me/proj": fake},
+        )
+        with patches[0], patches[1], patches[2]:
+            result = load_conversations("/home/me/proj")
+
+        assert len(result) == 1
+        ref = next(iter(result.values()))
+        assert ref.worktree is None
+
+    def test_main_plus_linked_worktrees(self):
+        """First worktree (main) → None; others → basename label."""
+        main_dir = _FakeDir(["/claude/-proj/aaaa1111.jsonl"])
+        wt1_dir = _FakeDir(["/claude/-proj--wt-happy/bbbb2222.jsonl"])
+        wt2_dir = _FakeDir(["/claude/-proj--wt-brave/cccc3333.jsonl"])
+
+        patches = _patch(
+            worktree_paths=[
+                "/home/me/proj",
+                "/home/me/proj/.claude-worktrees/happy-lehmann",
+                "/home/me/proj/.claude-worktrees/brave-borg",
+            ],
+            find_map={
+                "/home/me/proj": main_dir,
+                "/home/me/proj/.claude-worktrees/happy-lehmann": wt1_dir,
+                "/home/me/proj/.claude-worktrees/brave-borg": wt2_dir,
+            },
+        )
+        with patches[0], patches[1], patches[2]:
+            result = load_conversations("/home/me/proj")
+
+        assert len(result) == 3
+        by_stem = {ref.path.stem: ref for ref in result.values()}
+        assert by_stem["aaaa1111"].worktree is None
+        assert by_stem["bbbb2222"].worktree == "happy-lehmann"
+        assert by_stem["cccc3333"].worktree == "brave-borg"
+
+    def test_missing_worktree_project_dir_is_skipped(self):
+        """A worktree whose project dir doesn't exist yet is silently skipped."""
+        main_dir = _FakeDir(["/claude/-proj/aaaa1111.jsonl"])
+        patches = _patch(
+            worktree_paths=[
+                "/home/me/proj",
+                "/home/me/proj/.claude-worktrees/never-used",
+            ],
+            find_map={
+                "/home/me/proj": main_dir,
+                "/home/me/proj/.claude-worktrees/never-used": None,  # not found
+            },
+        )
+        with patches[0], patches[1], patches[2]:
+            result = load_conversations("/home/me/proj")
+
+        assert len(result) == 1
+        assert next(iter(result.values())).worktree is None
+
+    def test_duplicate_session_prefers_main_worktree(self):
+        """If the same session UUID appears in main + linked, main wins."""
+        main_dir = _FakeDir(["/claude/-proj/shared111.jsonl"])
+        wt_dir = _FakeDir(["/claude/-proj--wt-x/shared111.jsonl"])
+
+        patches = _patch(
+            worktree_paths=[
+                "/home/me/proj",
+                "/home/me/proj/.claude-worktrees/x",
+            ],
+            find_map={
+                "/home/me/proj": main_dir,
+                "/home/me/proj/.claude-worktrees/x": wt_dir,
+            },
+        )
+        with patches[0], patches[1], patches[2]:
+            result = load_conversations("/home/me/proj")
+
+        assert len(result) == 1
+        ref = next(iter(result.values()))
+        assert ref.worktree is None  # main (first-wins)

--- a/project-mining/uv.lock
+++ b/project-mining/uv.lock
@@ -111,7 +111,7 @@ wheels = [
 
 [[package]]
 name = "cc-explorer"
-version = "1.22.1"
+version = "1.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
## Why

Claude Desktop dispatch creates real git worktrees under `<project>/.claude-worktrees/<name>/`, and each gets its own sanitized directory in `~/.claude/projects/`. Previously `load_conversations()` only scanned the main worktree's dir, so dispatched work was silently invisible to every cc-explorer tool.

Smoke check on `social-media-history`: **163 total sessions, 150 main + 13 dispatch worktrees.** Before this change, only 150 were visible — 13 sessions of real work were missing from every mining run with no error, no warning, nothing.

## What changed

- **`load_conversations()`** now uses the agent SDK's `_get_worktree_paths` helper (shells out to `git worktree list --porcelain`) to enumerate every worktree of the project and pool their sessions. The main worktree (first in git's output) gets `worktree=None`; linked worktrees are labeled with their directory basename. Falls back to single-dir scanning when git is unavailable.
- **New `ConversationRef`** dataclass replaces the raw `dict[PrefixId, Path]` return — carries both path and worktree label.
- **`SessionInfo`** and every single-session response model (`SessionSummary`, `GrepSessionResponse`, `ReadTurnResponse`, `BrowseSessionResponse`, `SessionAgentsResponse`, `AgentDetailResponse`, `SessionToolAuditResponse`) now carry an optional `worktree` field so researchers see which worktree a session came from without a second lookup.
- **Skill + agent docs** explain what the label means and how to calibrate on it: dispatched sessions are weaker evidence for "user's own words in the moment" but stronger evidence for "agent autonomy," and the worktree name doubles as a git branch bridge for cross-referencing chat evidence with commits.
- **Tests:** 5 new tests in `test_worktree_unification.py` covering no-git fallback, main-only, main + multiple linked worktrees, missing worktree project dirs, and duplicate-session main-wins ordering.

## No special-casing of `.claude-worktrees/`

The first draft considered parsing `--claude-worktrees-` out of the encoded project dir name. That's unnecessary — Claude Desktop's dispatched worktrees are *real* git worktrees, so `git worktree list` picks them up automatically. Any git worktree of the project now gets pooled, not just dispatched ones.

## Version bumps

- `plugin.json`: 2.22.1 → 2.23.0
- `pyproject.toml`: 1.22.1 → 1.23.0 (cc-explorer)

## Test plan

- [x] `uv run pytest` — 153 pass (148 prior + 5 new)
- [x] `uv run pyright src` — 0 errors, 0 warnings
- [x] Live smoke check against `~/projects/social-media-history` — 13 previously-invisible worktree sessions now pooled and labeled correctly
- [ ] Reload the plugin in Claude Code and run `list_project_sessions` on a project with worktrees — verify the `worktree` column appears in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)