### PR TITLE
cc-explorer: surface orphan subagent transcripts in forensics tools

### DIFF
--- a/project-mining/.claude-plugin/plugin.json
+++ b/project-mining/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-mining",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "description": "Mine project histories for behavioral evidence. Search chat logs, git history, docs, and code for concrete examples of specific patterns, values, or skills.",
   "author": {
     "name": "Cory King",

--- a/project-mining/pyproject.toml
+++ b/project-mining/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-explorer"
-version = "1.28.0"
+version = "1.29.0"
 description = "MCP server for exploring Claude Code chat history — search conversations, quote moments, inspect subagents."
 requires-python = ">=3.11"
 dependencies = [

--- a/project-mining/src/cc_explorer/mcp_server.py
+++ b/project-mining/src/cc_explorer/mcp_server.py
@@ -45,8 +45,8 @@ from .search import (
     triage_multi,
 )
 from .subagents import (
+    discover_subagents,
     extract_agent_tool_audit,
-    extract_subagents,
     resolve_output_files,
     scan_output_file_stats,
 )
@@ -63,11 +63,11 @@ another). There are two lenses:
    grep_session / grep_sessions for matches-in-context, read_turn /
    browse_session to read at full fidelity.
 
-2. Agent forensics — see what dispatched subagents actually did.
+2. Agent forensics — see what a session's subagents actually did.
    Start from list_project_sessions(min_agents=1) to find sessions that spawned
-   agents, then list_session_agents to see which agents a session dispatched,
-   get_agent_detail for one agent's prompt / result / tool-trace, and
-   audit_session_tools to check whether the agents used their tools correctly
+   agents, then list_session_agents to see every agent the session ran (workflow
+   ones included), get_agent_detail for one agent's prompt / result / tool-trace,
+   and audit_session_tools to check whether the agents used their tools correctly
    (per-tool counts, error rates, retries).
 """
 
@@ -728,7 +728,9 @@ def list_session_agents(
         Field(description="Directory containing saved .output files."),
     ] = None,
 ) -> SessionAgentsResponse:
-    """List the subagents one session dispatched — type, status, token cost, duration, and whether each agent's output file is available.
+    """List every subagent a session ran — type, status, token cost, duration, and whether its full record is available.
+
+    Includes agents spawned by a workflow, not just ones the conversation dispatched directly, so the count reflects the session's real fan-out. Each row's `source` tells you whether to trust missing fields — and `workflow_run_id` lets you group agents from the same workflow run.
 
     Use when you want to see a session's fan-out before drilling in: which agents ran, which errored, which burned the most tokens. Step two of agent forensics — get a session id from list_project_sessions(min_agents=1), then from here pass an agent_id to get_agent_detail for the full prompt/result/trace, or audit the whole session's tool usage with audit_session_tools.
     """
@@ -746,7 +748,7 @@ def list_session_agents(
     if not target:
         raise ToolError(f"Session {session} not found")
 
-    agents = extract_subagents(target.path)
+    agents = discover_subagents(target.path)
 
     output_dir = Path(task_output_dir).expanduser() if task_output_dir else None
     resolve_output_files(agents, output_dir)
@@ -792,7 +794,9 @@ def get_agent_detail(
 ) -> AgentDetailResponse | AgentListResponse:
     """Get one or more subagents' full story: the prompt they were given, the result they returned, token/tool stats, and (with trace=true) a chronological tool-by-tool timeline of what they did.
 
-    Use when you need what an agent was actually told and how it reached its answer — debugging why an agent went off the rails, recovering a result that scrolled out of context, or comparing what several parallel agents concluded. Find agent_ids with list_session_agents. For a session-wide view of whether agents used their tools correctly (rather than one agent's full transcript), use audit_session_tools instead.
+    Works for any agent list_session_agents returns, including ones a workflow spawned rather than the conversation requesting directly. Find agent_ids with list_session_agents.
+
+    Use when you need what an agent was actually told and how it reached its answer — debugging why an agent went off the rails, recovering a result that scrolled out of context, or comparing what several parallel agents concluded. For a session-wide view of whether agents used their tools correctly (rather than one agent's full transcript), use audit_session_tools instead.
     """
     proj = resolve_project(project)
     sessions = load_sessions(proj)
@@ -839,7 +843,7 @@ def get_agent_detail(
 def _find_agent(sessions, agent_id: str):
     """Search for an agent across sessions by ID prefix."""
     for s in sessions:
-        agents = extract_subagents(s.path)
+        agents = discover_subagents(s.path)
         for sa in agents:
             if matches_id(sa, agent_id):
                 return sa, s
@@ -878,9 +882,9 @@ def audit_session_tools(
 ) -> SessionToolAuditResponse:
     """Audit how every subagent in a session used its tools — the whole-session view, vs get_agent_detail's single-agent deep dive.
 
-    For each subagent in the target session, walks the agent's transcript and returns: tool counts, error rate, and a chronological list of tool calls (optionally filtered by name substring via tool_name_filter). Each call includes timestamp, tool name, truncated input args, and an error flag set when the tool result was an error or zero-match response.
+    Covers agents spawned by a workflow, not just ones the conversation dispatched directly, so a workflow's fan-out is audited rather than silently missing from the picture. `total_present` is how many agents the session ran; `total_audited` is how many could be inspected — a gap means some agents left no inspectable record. For each agent, returns tool counts, error rate, and a chronological list of tool calls (optionally filtered by name substring via tool_name_filter); each call includes timestamp, tool name, truncated input args, and an error flag set when the tool result was an error or zero-match response.
 
-    Use this to answer 'are my agents using my tools right?' — which tools land vs fail, where retries happened, which agents over-call, and (with tool_name_filter='your-server') whether agents even reached for a specific MCP tool you shipped or ignored it. Get the session id from list_project_sessions(min_agents=1). Replaces hand-rolled scripts that walk the per-agent JSONL files in `<session_dir>/subagents/`.
+    Use this to answer 'are my agents using my tools right?' — which tools land vs fail, where retries happened, which agents over-call, and (with tool_name_filter='your-server') whether agents even reached for a specific MCP tool you shipped or ignored it. Get the session id from list_project_sessions(min_agents=1).
     """
     proj = resolve_project(project)
     sessions = load_sessions(proj)
@@ -891,11 +895,11 @@ def audit_session_tools(
     if target is None:
         raise ToolError(f"Session {session} not found")
 
-    agents = extract_subagents(target.path)
+    agents = discover_subagents(target.path)
     if not agents:
         raise ToolError(f"Session {session} dispatched no subagents")
 
-    total_dispatched = len(agents)
+    total_present = len(agents)
 
     output_dir = Path(task_output_dir).expanduser() if task_output_dir else None
     resolve_output_files(agents, output_dir)
@@ -920,6 +924,8 @@ def audit_session_tools(
         audits.append(
             AgentToolAudit(
                 agent_id=sa.agent_id,
+                source=sa.source,
+                workflow_run_id=sa.workflow_run_id,
                 type=sa.subagent_type or "",
                 description=sa.description or "",
                 tool_call_count=agent_total,
@@ -929,17 +935,17 @@ def audit_session_tools(
             )
         )
 
-    # When total_dispatched > 0 but total_audited == 0, return the response
-    # anyway with empty agents — that asymmetry IS the signal the new
-    # total_dispatched/total_audited fields exist to surface. Only the
-    # zero-dispatched case (handled above) raises ToolError, since there
-    # genuinely isn't anything to report on.
+    # When total_present > 0 but total_audited == 0, return the response anyway
+    # with empty agents — that asymmetry IS the signal the
+    # total_present/total_audited fields exist to surface. Only the
+    # zero-present case (handled above) raises ToolError, since there genuinely
+    # isn't anything to report on.
 
     return SessionToolAuditResponse(
         session=PrefixId(target.session_id),
         worktree=target.worktree,
         title=target.title,
-        total_dispatched=total_dispatched,
+        total_present=total_present,
         total_audited=len(audits),
         total_tool_calls=total_calls,
         total_errors=total_errors,

--- a/project-mining/src/cc_explorer/responses.py
+++ b/project-mining/src/cc_explorer/responses.py
@@ -399,6 +399,13 @@ class AgentSummary(SparseModel):
 
     agent_id: PrefixId = Field(description="Agent identifier.")
     tool_use_id: PrefixId = Field(description="Tool use ID that spawned this agent.")
+    source: str = Field(
+        description="Whether this agent's record is complete and how it relates to the conversation. 'dispatched' — the conversation requested it and its full run is available. 'dispatch_only' — the conversation requested it but no run is available (rejected, never started, or no longer kept), so result/stats/trace will be missing. 'orphan' — it ran with a full record but the conversation didn't request it directly, typically because a workflow spawned it."
+    )
+    workflow_run_id: str | None = Field(
+        default=None,
+        description="The workflow run this agent belongs to; null if it wasn't spawned by a workflow. Agents sharing a value ran in the same workflow.",
+    )
     date: datetime | None = Field(default=None, description="Timestamp when agent was spawned.")
     type: str = Field(description="Subagent type (e.g. 'general-purpose', 'Explore').")
     status: str = Field(description="Agent status: completed, error, async_launched, unknown.")
@@ -413,6 +420,8 @@ class AgentSummary(SparseModel):
         return cls(
             agent_id=sa.agent_id,
             tool_use_id=sa.tool_use_id,
+            source=sa.source,
+            workflow_run_id=sa.workflow_run_id,
             date=sa.timestamp,
             type=sa.subagent_type or "",
             status=sa.status,
@@ -479,6 +488,13 @@ class AgentDetailResponse(SparseModel):
     title: str | None = Field(default=None, description="Session title.")
     agent_id: PrefixId = Field(description="Agent identifier.")
     tool_use_id: PrefixId = Field(description="Tool use ID that spawned this agent.")
+    source: str = Field(
+        description="Whether this agent's record is complete and how it relates to the conversation. 'dispatched' — the conversation requested it and its full run is available. 'dispatch_only' — the conversation requested it but no run is available (rejected, never started, or no longer kept), so result/stats/trace will be missing. 'orphan' — it ran with a full record but the conversation didn't request it directly, typically because a workflow spawned it."
+    )
+    workflow_run_id: str | None = Field(
+        default=None,
+        description="The workflow run this agent belongs to; null if it wasn't spawned by a workflow. Agents sharing a value ran in the same workflow.",
+    )
     type: str = Field(description="Subagent type.")
     status: str = Field(description="Agent status.")
     date_started: datetime | None = Field(default=None, description="Timestamp when agent was spawned.")
@@ -531,6 +547,8 @@ class AgentDetailResponse(SparseModel):
             title=found_session.title,
             agent_id=found.agent_id,
             tool_use_id=found.tool_use_id,
+            source=found.source,
+            workflow_run_id=found.workflow_run_id,
             type=found.subagent_type or "",
             status=found.status,
             date_started=found.timestamp,
@@ -571,6 +589,13 @@ class AgentToolAudit(SparseModel):
     """Per-agent tool usage audit: counts, error rate, full chronological trace."""
 
     agent_id: PrefixId = Field(description="Agent identifier.")
+    source: str = Field(
+        description="Whether this agent's record is complete and how it relates to the conversation. 'dispatched' — the conversation requested it and its full run is available. 'dispatch_only' — the conversation requested it but no run is available (rejected, never started, or no longer kept), so result/stats/trace will be missing. 'orphan' — it ran with a full record but the conversation didn't request it directly, typically because a workflow spawned it."
+    )
+    workflow_run_id: str | None = Field(
+        default=None,
+        description="The workflow run this agent belongs to; null if it wasn't spawned by a workflow. Agents sharing a value ran in the same workflow.",
+    )
     type: str = Field(description="Subagent type.")
     description: str = Field(description="Short description passed to the agent.")
     tool_call_count: int = Field(description="Total tool invocations made by this agent.")
@@ -597,11 +622,11 @@ class SessionToolAuditResponse(SparseModel):
         description="Git worktree name this session lived in, if not the main one.",
     )
     title: str | None = Field(default=None, description="Session title.")
-    total_dispatched: int = Field(
-        description="Number of subagents the session spawned, regardless of whether their output files were accessible. This is the truth about how much fan-out happened."
+    total_present: int = Field(
+        description="How many subagents the session ran in total, including any spawned by workflows. The real measure of fan-out."
     )
     total_audited: int = Field(
-        description="Number of subagents this audit could actually inspect — the subset of dispatched agents whose .output files were readable. When this is less than total_dispatched, work was skipped and the agents list reflects only the audited subset."
+        description="How many of those agents could be inspected. When this is less than total_present, the difference is agents that left no inspectable record (rejected, never ran, or unreadable) — they are absent from `agents`."
     )
     total_tool_calls: int = Field(description="Aggregate tool calls across all audited agents.")
     total_errors: int = Field(description="Aggregate error/no-match results across all audited agents.")

--- a/project-mining/src/cc_explorer/subagents.py
+++ b/project-mining/src/cc_explorer/subagents.py
@@ -30,6 +30,7 @@ from .models import (
     AssistantTranscriptEntry,
     CompactionEvent,
     ContentItem,
+    HumanEntry,
     QueueOperationTranscriptEntry,
     TextContent,
     ToolResultContent,
@@ -37,6 +38,7 @@ from .models import (
     ToolUseContent,
     TranscriptEntry,
     TranscriptStats,
+    extract_text,
 )
 from .parser import load_transcript
 from .utils import PrefixId
@@ -54,6 +56,15 @@ class SubagentInfo:
     result_text: str = ""
     status: str = "unknown"
     timestamp: Optional[datetime] = None
+
+    # Discovery provenance — how this subagent was found. See discover_subagents.
+    #   "dispatched"    — seen in the parent transcript AND its on-disk transcript was found
+    #   "dispatch_only" — seen in the parent transcript, but no on-disk transcript matched
+    #   "orphan"        — on-disk transcript with no correlating parent dispatch
+    #                     (workflow-orchestrated agents, or any spawn the parent didn't record)
+    source: str = ""
+    # Workflow run id for agents under subagents/workflows/<runId>/, else None.
+    workflow_run_id: Optional[str] = None
 
     # Completion stats (from toolUseResult on completed agents)
     # Optional here is meaningful — distinguishes "no data" from "zero usage"
@@ -203,6 +214,196 @@ def extract_subagents(transcript_path: Path) -> list[SubagentInfo]:
     return [spawns[tid] for tid in spawn_order if tid in spawns]
 
 
+# =============================================================================
+# Bottom-up discovery: walk the on-disk subagent transcripts
+# =============================================================================
+#
+# extract_subagents (above) is the TOP-DOWN view: it parses the parent
+# transcript's Task/Agent/TaskCreate blocks, so it only ever sees agents whose
+# spawn the parent recorded. A child agent whose dispatch isn't in the parent —
+# notably workflow-orchestrated agents under subagents/workflows/<runId>/ — is
+# invisible to it.
+#
+# collect_agent_files is the BOTTOM-UP counterpart: it walks the filesystem
+# tree where Claude Code stores child transcripts and finds every agent-*.jsonl,
+# orphan or not. discover_subagents reconciles the two. (The walk mirrors the
+# claude-agent-sdk's _collect_agent_files / _resolve_subagents_dir, which we
+# reimplement here rather than vendoring — see _claude_paths.py for why the
+# path-resolution slice was the only part worth carrying.)
+
+
+@dataclass
+class AgentFile:
+    """An on-disk subagent transcript located by the filesystem walk.
+
+    `tool_use_id`/`agent_type`/`description` come from the `.meta.json` sidecar
+    Claude Code writes next to each transcript; older sessions may lack it, in
+    which case those stay empty and correlation falls back to `agent_id`.
+    """
+
+    agent_id: str  # full id, from the agent-<id>.jsonl filename
+    path: Path  # the transcript file
+    workflow_run_id: Optional[str] = None  # runId if under subagents/workflows/<runId>/
+    agent_type: str = ""  # meta.json agentType
+    description: str = ""  # meta.json description
+    tool_use_id: str = ""  # meta.json toolUseId (links back to a parent dispatch)
+
+
+def resolve_subagents_dir(session_path: Path) -> Path:
+    """Map a session transcript path to its subagents directory.
+
+    The session file lives at `<projectDir>/<sessionId>.jsonl` and its child
+    agent transcripts at `<projectDir>/<sessionId>/subagents/`. Resolution is
+    purely relative to where the session file already is, so worktree-pooled
+    sessions resolve correctly without re-deriving the project dir.
+    """
+    return session_path.with_suffix("") / "subagents"
+
+
+def _workflow_run_id(path: Path, base_dir: Path) -> Optional[str]:
+    """Extract the workflow runId from a transcript path, if it's under workflows/."""
+    try:
+        parts = path.relative_to(base_dir).parts
+    except ValueError:
+        parts = path.parts
+    if "workflows" in parts:
+        idx = parts.index("workflows")
+        if idx + 1 < len(parts):
+            return parts[idx + 1]
+    return None
+
+
+def _read_agent_meta(transcript_path: Path) -> dict[str, str]:
+    """Read the `.meta.json` sidecar next to an agent transcript. Empty dict if absent."""
+    meta_path = transcript_path.with_suffix(".meta.json")
+    try:
+        data = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def collect_agent_files(subagents_dir: Path) -> list[AgentFile]:
+    """Recursively collect every `agent-*.jsonl` transcript under a subagents dir.
+
+    Walks nested directories (notably `workflows/<runId>/`) and reads each
+    transcript's `.meta.json` sidecar. Returns AgentFile records sorted by
+    filename for stable ordering. Empty list if the directory doesn't exist.
+    """
+    if not subagents_dir.is_dir():
+        return []
+
+    found: list[AgentFile] = []
+
+    def _walk(current: Path) -> None:
+        try:
+            entries = sorted(current.iterdir(), key=lambda p: p.name)
+        except OSError:
+            return
+        for entry in entries:
+            name = entry.name
+            if entry.is_dir():
+                _walk(entry)
+            elif (
+                entry.is_file()
+                and name.startswith("agent-")
+                and name.endswith(".jsonl")
+            ):
+                agent_id = name[len("agent-") : -len(".jsonl")]
+                meta = _read_agent_meta(entry)
+                found.append(
+                    AgentFile(
+                        agent_id=agent_id,
+                        path=entry,
+                        workflow_run_id=_workflow_run_id(entry, subagents_dir),
+                        agent_type=meta.get("agentType", ""),
+                        description=meta.get("description", ""),
+                        tool_use_id=meta.get("toolUseId", ""),
+                    )
+                )
+
+    _walk(subagents_dir)
+    return found
+
+
+def _attach_transcript_file(info: SubagentInfo, path: Path) -> None:
+    """Point a SubagentInfo at its on-disk transcript (resolved output file)."""
+    info.output_file_resolved = str(path)
+    try:
+        info.output_file_size = path.stat().st_size
+        info.output_file_exists = True
+    except OSError:
+        info.output_file_exists = False
+
+
+def discover_subagents(session_path: Path) -> list[SubagentInfo]:
+    """Full subagent population for a session: parent dispatches + orphan files.
+
+    Reconciles the top-down dispatch graph (extract_subagents) with the
+    bottom-up filesystem walk (collect_agent_files):
+
+      - A dispatch that matches an on-disk transcript (by the sidecar's
+        toolUseId, falling back to agentId) is enriched in place — its agent_id
+        is backfilled if missing, its transcript path resolved, source set to
+        "dispatched".
+      - A transcript with no correlating dispatch becomes a fresh orphan
+        SubagentInfo (source="orphan"); its prompt/result/stats are recovered
+        later from the transcript by scan_output_file_stats.
+      - A dispatch with no on-disk transcript (rejected, never ran, or cleaned
+        up) is kept with source="dispatch_only".
+
+    Dispatched/dispatch_only entries preserve parent transcript order; orphans
+    follow, ordered by filename.
+    """
+    dispatched = extract_subagents(session_path)
+    files = collect_agent_files(resolve_subagents_dir(session_path))
+
+    by_tool_use: dict[str, SubagentInfo] = {}
+    by_agent_id: dict[str, SubagentInfo] = {}
+    for sa in dispatched:
+        if sa.tool_use_id:
+            by_tool_use[sa.tool_use_id.full] = sa
+        if sa.agent_id:
+            by_agent_id[sa.agent_id.full] = sa
+
+    matched: set[int] = set()
+    orphans: list[SubagentInfo] = []
+
+    for af in files:
+        target: Optional[SubagentInfo] = None
+        if af.tool_use_id and af.tool_use_id in by_tool_use:
+            target = by_tool_use[af.tool_use_id]
+        elif af.agent_id in by_agent_id:
+            target = by_agent_id[af.agent_id]
+
+        if target is not None:
+            if not target.agent_id:
+                target.agent_id = PrefixId(af.agent_id)
+            target.workflow_run_id = af.workflow_run_id
+            target.source = "dispatched"
+            _attach_transcript_file(target, af.path)
+            matched.add(id(target))
+        else:
+            info = SubagentInfo(
+                tool_use_id=PrefixId(af.tool_use_id),
+                agent_id=PrefixId(af.agent_id),
+                subagent_type=af.agent_type,
+                description=af.description,
+                workflow_run_id=af.workflow_run_id,
+                source="orphan",
+            )
+            _attach_transcript_file(info, af.path)
+            orphans.append(info)
+
+    for sa in dispatched:
+        if id(sa) not in matched:
+            sa.source = "dispatch_only"
+
+    return dispatched + orphans
+
+
 def _content_as_list(
     content: Union[str, list[ContentItem]],
 ) -> list[ContentItem]:
@@ -316,6 +517,26 @@ def _extract_tool_result_text(
     return ""
 
 
+def _first_user_text(entries: list[TranscriptEntry]) -> str:
+    """First human turn's text — a subagent's spawn prompt, recovered from its transcript."""
+    for entry in entries:
+        if isinstance(entry, HumanEntry):
+            text = extract_text(entry).strip()
+            if text:
+                return text
+    return ""
+
+
+def _last_assistant_text(entries: list[TranscriptEntry]) -> str:
+    """Last assistant turn's text — a subagent's result, recovered from its transcript."""
+    for entry in reversed(entries):
+        if isinstance(entry, AssistantTranscriptEntry):
+            text = extract_text(entry).strip()
+            if text:
+                return text
+    return ""
+
+
 def resolve_output_files(
     subagents: list[SubagentInfo],
     task_output_dir: Optional[Path] = None,
@@ -340,6 +561,12 @@ def resolve_output_files(
             info.output_file_resolved = str(resolved)
             info.output_file_exists = True
             info.output_file_size = resolved.stat().st_size
+            continue
+
+        # If discover_subagents already resolved the on-disk transcript, leave
+        # it — the filesystem walk is the canonical location. task_output_dir
+        # above is the only thing allowed to override it.
+        if info.output_file_resolved:
             continue
 
         # Fall back to original outputFile path
@@ -378,6 +605,14 @@ def scan_output_file_stats(
             continue
 
         info.output_entry_count = len(entries)
+
+        # Recover prompt/result from the transcript when the parent didn't
+        # supply them — orphan agents have no parent-side record at all, and
+        # async dispatches often lack result text until their transcript is read.
+        if not info.prompt:
+            info.prompt = _first_user_text(entries)
+        if not info.result_text:
+            info.result_text = _last_assistant_text(entries)
 
         stats = TranscriptStats.from_entries(entries)
         info.compaction_events = list(stats.compaction_events)

--- a/project-mining/tests/test_audit_fixes.py
+++ b/project-mining/tests/test_audit_fixes.py
@@ -25,14 +25,14 @@ What's pinned and why:
     When *every* prefix fails to resolve, the tool raises ToolError
     instead, since there's nothing useful to return.
 
-  TestSessionToolAuditResponseHasDispatchVsAuditedCounts
+  TestSessionToolAuditResponseHasPresentVsAuditedCounts
   TestSessionToolAuditCountsReflectSkippedAgents
-    audit_session_tools can only audit subagents whose .output files are
-    accessible. The response has to expose both `total_dispatched` (every
-    subagent the session spawned) and `total_audited` (the subset whose
-    output files were readable), so callers can see when work was skipped.
-    A single `total_agents` field would be ambiguous and would hide the
-    gap.
+    audit_session_tools can only audit subagents whose transcript is
+    readable. The response has to expose both `total_present` (every
+    subagent discovered — dispatched plus orphan transcripts on disk) and
+    `total_audited` (the subset whose transcript was readable), so callers
+    can see when work was skipped. A single `total_agents` field would be
+    ambiguous and would hide the gap.
 
   TestGrepSessionsPreservesInputOrder
   TestGrepSessionsOmitsZeroHitSessions
@@ -224,29 +224,32 @@ class TestGrepSessionsSurfacesUnresolvedPrefixes:
 # agent. Not every spawned subagent has a readable output file — some get
 # skipped. The response exposes two separate counts so the caller can see
 # the gap:
-#   - total_dispatched: every subagent the session spawned
-#   - total_audited:    the subset whose output files were accessible
-# A single ambiguous `total_agents` field (was it dispatched? was it
+#   - total_present:  every subagent discovered (dispatched + orphan transcripts)
+#   - total_audited:  the subset whose transcript was readable
+# A single ambiguous `total_agents` field (was it present? was it
 # audited?) would hide the skipped work entirely, so the response model
 # must carry both — and the ambiguous name must not be present.
 
 
-class TestSessionToolAuditResponseHasDispatchVsAuditedCounts:
-    def test_response_model_has_total_dispatched_and_total_audited(self):
+class TestSessionToolAuditResponseHasPresentVsAuditedCounts:
+    def test_response_model_has_total_present_and_total_audited(self):
         from cc_explorer.responses import SessionToolAuditResponse
 
         fields = SessionToolAuditResponse.model_fields
-        assert "total_dispatched" in fields, (
-            "Need total_dispatched: number of subagents the session spawned, "
-            "regardless of whether their output files were accessible."
+        assert "total_present" in fields, (
+            "Need total_present: every subagent discovered for the session — "
+            "parent-dispatched plus orphan transcripts found on disk."
         )
         assert "total_audited" in fields, (
-            "Rename total_agents -> total_audited so it's clear it's the "
-            "subset with accessible output files."
+            "total_audited: the subset whose transcript was readable."
+        )
+        assert "total_dispatched" not in fields, (
+            "total_dispatched was renamed to total_present once discovery became "
+            "bottom-up: orphan transcripts are present without being dispatched. "
+            "Toolbox, not product — no backwards-compat shim."
         )
         assert "total_agents" not in fields, (
-            "Drop total_agents — its meaning was ambiguous (audited or dispatched?). "
-            "Toolbox, not product — no backwards-compat shim."
+            "Drop total_agents — its meaning was ambiguous (audited or present?)."
         )
 
 
@@ -299,7 +302,7 @@ class TestSessionToolAuditCountsReflectSkippedAgents:
             return [], {}, 0
 
         with patch("cc_explorer.mcp_server.load_sessions", return_value=sessions), \
-             patch("cc_explorer.mcp_server.extract_subagents", return_value=all_agents), \
+             patch("cc_explorer.mcp_server.discover_subagents", return_value=all_agents), \
              patch("cc_explorer.mcp_server.resolve_output_files", side_effect=fake_resolve), \
              patch("cc_explorer.mcp_server.scan_output_file_stats", side_effect=fake_scan), \
              patch(
@@ -308,8 +311,8 @@ class TestSessionToolAuditCountsReflectSkippedAgents:
              ):
             resp = audit_session_tools(session="aaaaaaaa", project="/tmp/fake")
 
-        assert resp.total_dispatched == 3, (
-            f"3 agents were spawned, got total_dispatched={resp.total_dispatched}"
+        assert resp.total_present == 3, (
+            f"3 agents were present, got total_present={resp.total_present}"
         )
         assert resp.total_audited == 1, (
             f"only 1 had an accessible output file, got total_audited={resp.total_audited}"
@@ -317,9 +320,9 @@ class TestSessionToolAuditCountsReflectSkippedAgents:
         assert len(resp.agents) == 1
 
     def test_zero_audited_returns_response_not_raises(self):
-        """When dispatched > 0 but every output file is missing, the tool
+        """When present > 0 but every transcript is missing, the tool
         returns the response with empty agents — it does NOT raise. The
-        total_dispatched > 0 / total_audited == 0 asymmetry is exactly the
+        total_present > 0 / total_audited == 0 asymmetry is exactly the
         signal these new fields exist to surface; raising would hide it.
         """
         from cc_explorer.mcp_server import audit_session_tools
@@ -345,12 +348,12 @@ class TestSessionToolAuditCountsReflectSkippedAgents:
         ]
 
         with patch("cc_explorer.mcp_server.load_sessions", return_value=sessions), \
-             patch("cc_explorer.mcp_server.extract_subagents", return_value=all_agents), \
+             patch("cc_explorer.mcp_server.discover_subagents", return_value=all_agents), \
              patch("cc_explorer.mcp_server.resolve_output_files", side_effect=lambda *a, **k: None), \
              patch("cc_explorer.mcp_server.scan_output_file_stats", return_value={}):
             resp = audit_session_tools(session="aaaaaaaa", project="/tmp/fake")
 
-        assert resp.total_dispatched == 2
+        assert resp.total_present == 2
         assert resp.total_audited == 0
         assert resp.agents == []
 

--- a/project-mining/tests/test_discover_subagents.py
+++ b/project-mining/tests/test_discover_subagents.py
@@ -1,0 +1,237 @@
+"""Tests for bottom-up subagent discovery and its reconciliation with the
+top-down dispatch parse.
+
+extract_subagents only sees agents whose spawn the parent transcript recorded.
+discover_subagents adds a filesystem walk over `<session>/subagents/**` so
+orphan transcripts — notably workflow-orchestrated agents under
+`subagents/workflows/<runId>/` — stop being invisible. These tests pin:
+
+  - collect_agent_files: recursive walk, meta.json sidecar parsing, workflow
+    runId extraction, missing-meta tolerance.
+  - discover_subagents merge matrix: dispatched+file (dispatched),
+    dispatched-no-file (dispatch_only), file-no-dispatch (orphan).
+  - scan_output_file_stats recovering an orphan's prompt/result from its own
+    transcript, since the parent has no record of it.
+"""
+
+import json
+from pathlib import Path
+
+from cc_explorer.subagents import (
+    AgentFile,
+    collect_agent_files,
+    discover_subagents,
+    resolve_subagents_dir,
+    scan_output_file_stats,
+)
+
+SID = "5c23db0a-12d4-4042-9119-738da66c60e0"
+TS = "2026-03-15T10:30:00.000Z"
+
+
+def _write_jsonl(path: Path, entries: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+
+def _agent_transcript(agent_id: str, prompt: str, result: str) -> list[dict]:
+    """A minimal but parser-valid subagent transcript: one user turn, one assistant turn."""
+    return [
+        {
+            "type": "user",
+            "uuid": f"u-{agent_id}",
+            "timestamp": TS,
+            "sessionId": SID,
+            "agentId": agent_id,
+            "message": {"role": "user", "content": [{"type": "text", "text": prompt}]},
+        },
+        {
+            "type": "assistant",
+            "uuid": f"a-{agent_id}",
+            "parentUuid": f"u-{agent_id}",
+            "timestamp": TS,
+            "sessionId": SID,
+            "agentId": agent_id,
+            "message": {
+                "id": "m1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-opus-4",
+                "content": [{"type": "text", "text": result}],
+            },
+        },
+    ]
+
+
+def _dispatch_assistant(tool_use_id: str, prompt: str, desc: str) -> dict:
+    return {
+        "type": "assistant",
+        "uuid": f"asst-{tool_use_id}",
+        "timestamp": TS,
+        "sessionId": SID,
+        "message": {
+            "id": "mm",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": tool_use_id,
+                    "name": "Agent",
+                    "input": {
+                        "description": desc,
+                        "subagent_type": "general-purpose",
+                        "prompt": prompt,
+                    },
+                }
+            ],
+        },
+    }
+
+
+def _dispatch_result(tool_use_id: str, agent_id: str) -> dict:
+    return {
+        "type": "user",
+        "uuid": f"res-{tool_use_id}",
+        "timestamp": TS,
+        "sessionId": SID,
+        "toolUseResult": {
+            "status": "completed",
+            "agentId": agent_id,
+            "totalTokens": 1234,
+        },
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": [{"type": "text", "text": "done"}],
+                }
+            ],
+        },
+    }
+
+
+def _meta(path: Path, **fields) -> None:
+    path.with_suffix(".meta.json").write_text(json.dumps(fields), encoding="utf-8")
+
+
+# =============================================================================
+# Filesystem walk
+# =============================================================================
+
+
+def test_resolve_subagents_dir_strips_jsonl_suffix(tmp_path):
+    session = tmp_path / f"{SID}.jsonl"
+    assert resolve_subagents_dir(session) == tmp_path / SID / "subagents"
+
+
+def test_collect_agent_files_missing_dir_is_empty(tmp_path):
+    assert collect_agent_files(tmp_path / "nope") == []
+
+
+def test_collect_agent_files_walks_nested_and_reads_meta(tmp_path):
+    subdir = tmp_path / SID / "subagents"
+    top = subdir / "agent-aaa111.jsonl"
+    nested = subdir / "workflows" / "wf_xyz" / "agent-bbb222.jsonl"
+    _write_jsonl(top, _agent_transcript("aaa111", "p", "r"))
+    _write_jsonl(nested, _agent_transcript("bbb222", "p", "r"))
+    _meta(top, agentType="Explore", description="top one", toolUseId="toolu_TOP")
+    _meta(nested, agentType="workflow-subagent")
+
+    files = {f.agent_id: f for f in collect_agent_files(subdir)}
+    assert set(files) == {"aaa111", "bbb222"}
+
+    assert files["aaa111"].workflow_run_id is None
+    assert files["aaa111"].agent_type == "Explore"
+    assert files["aaa111"].tool_use_id == "toolu_TOP"
+
+    assert files["bbb222"].workflow_run_id == "wf_xyz"
+    assert files["bbb222"].agent_type == "workflow-subagent"
+    assert files["bbb222"].tool_use_id == ""  # orphan — no parent dispatch recorded
+
+
+def test_collect_agent_files_tolerates_absent_meta(tmp_path):
+    subdir = tmp_path / SID / "subagents"
+    f = subdir / "agent-nometa.jsonl"
+    _write_jsonl(f, _agent_transcript("nometa", "p", "r"))
+    # no .meta.json written
+    [af] = collect_agent_files(subdir)
+    assert af == AgentFile(agent_id="nometa", path=f)
+
+
+# =============================================================================
+# Merge matrix
+# =============================================================================
+
+
+def _setup_session(tmp_path) -> Path:
+    """A session with: one dispatch that has a file, one dispatch with no file,
+    and one orphan workflow transcript with no dispatch."""
+    session = tmp_path / f"{SID}.jsonl"
+    _write_jsonl(
+        session,
+        [
+            _dispatch_assistant("toolu_HASFILE", "do the matched work", "matched"),
+            _dispatch_result("toolu_HASFILE", "aid_matched"),
+            # a dispatch whose transcript never landed on disk
+            _dispatch_assistant("toolu_NOFILE", "ran but no transcript", "ghost"),
+            _dispatch_result("toolu_NOFILE", "aid_ghost"),
+        ],
+    )
+    subdir = tmp_path / SID / "subagents"
+    matched = subdir / "agent-aid_matched.jsonl"
+    _write_jsonl(matched, _agent_transcript("aid_matched", "matched prompt", "matched result"))
+    _meta(matched, agentType="general-purpose", description="matched", toolUseId="toolu_HASFILE")
+
+    orphan = subdir / "workflows" / "wf_run1" / "agent-aid_orphan.jsonl"
+    _write_jsonl(
+        orphan,
+        _agent_transcript("aid_orphan", "ORPHAN PROMPT TEXT", "ORPHAN RESULT TEXT"),
+    )
+    _meta(orphan, agentType="workflow-subagent")
+    return session
+
+
+def test_discover_merge_sources(tmp_path):
+    by_source = {}
+    for a in discover_subagents(_setup_session(tmp_path)):
+        by_source.setdefault(a.source, []).append(a)
+
+    assert sorted(by_source) == ["dispatch_only", "dispatched", "orphan"]
+    assert len(by_source["dispatched"]) == 1
+    assert len(by_source["dispatch_only"]) == 1
+    assert len(by_source["orphan"]) == 1
+
+
+def test_discover_dispatched_gets_transcript_resolved(tmp_path):
+    agents = discover_subagents(_setup_session(tmp_path))
+    matched = next(a for a in agents if a.source == "dispatched")
+    # toolUseId correlation backfilled the agent_id and resolved the on-disk file
+    assert matched.agent_id == "aid_matched"
+    assert matched.output_file_exists
+    assert matched.output_file_resolved.endswith("agent-aid_matched.jsonl")
+    # parent-side prompt is preserved (the real spawn prompt, not the transcript copy)
+    assert matched.prompt == "do the matched work"
+
+
+def test_discover_orphan_recovers_prompt_and_result_from_transcript(tmp_path):
+    agents = discover_subagents(_setup_session(tmp_path))
+    orphan = next(a for a in agents if a.source == "orphan")
+    assert orphan.workflow_run_id == "wf_run1"
+    assert orphan.subagent_type == "workflow-subagent"
+    assert orphan.output_file_exists
+
+    # Parent has no record of an orphan — prompt/result come from its own transcript
+    scan_output_file_stats(agents)
+    assert orphan.prompt == "ORPHAN PROMPT TEXT"
+    assert orphan.result_text == "ORPHAN RESULT TEXT"
+
+
+def test_discover_dispatch_only_has_no_file(tmp_path):
+    agents = discover_subagents(_setup_session(tmp_path))
+    ghost = next(a for a in agents if a.source == "dispatch_only")
+    assert not ghost.output_file_exists
+    assert ghost.tool_use_id == "toolu_NOFILE"

--- a/project-mining/uv.lock
+++ b/project-mining/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "cc-explorer"
-version = "1.28.0"
+version = "1.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Closes #17.

## What

Subagent forensics discovered agents **top-down** — by parsing the parent transcript's `Task`/`Agent`/`TaskCreate` blocks — so any agent whose spawn the parent didn't record was invisible. Workflow-orchestrated agents (under `subagents/workflows/<runId>/`) were the main casualty.

On a real workflow session: `list_session_agents` reported **31 of 104** agents, and `audit_session_tools` silently dropped the **73** workflow agents' tool usage. No error, no hint anything was missing.

## How

Add a bottom-up filesystem walk and reconcile it with the existing dispatch parse, keeping the asymmetry the two views own (dispatch graph vs. orphan files):

- `collect_agent_files` / `resolve_subagents_dir` walk `<session>/subagents/**` for every `agent-*.jsonl` and its `.meta.json` sidecar.
- `discover_subagents` merges the walk with `extract_subagents`, correlating by the sidecar's `toolUseId` (falling back to `agentId`). Each agent carries a `source` (`dispatched` / `dispatch_only` / `orphan`) and `workflow_run_id`.
- The walk resolves every agent's transcript, so stats / trace / prompt / result now work **without `--task-output-dir`**; an orphan's prompt+result are recovered from its own transcript.
- All three forensics tools report the full population. Audit's `total_dispatched` → `total_present`.
- Tool descriptions rewritten in caller-facing terms (what each result means), not internal mechanics.

## Verification

End-to-end on the real session: `list_session_agents` now returns 104 (31 dispatched + 73 orphan), `audit_session_tools` reports `total_present=104 total_audited=104`, and `get_agent_detail` on an orphan recovers its full prompt and result.

New `test_discover_subagents.py` covers the walk + the full merge matrix; `test_audit_fixes.py` updated for the rename. 174 tests pass.

## Follow-up

Filed #18: `list_project_sessions`' agent count / `min_agents` filter is still top-down only, so it can undercount or hide pure-workflow sessions and disagrees with `list_session_agents`. Left out here to keep this scoped to the three forensics tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)