### PR TITLE
fix(cc-explorer): count full subagent population in list_project_sessions (#18)

### DIFF
--- a/project-mining/.claude-plugin/plugin.json
+++ b/project-mining/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-mining",
-  "version": "2.38.0",
+  "version": "2.39.0",
   "description": "Mine project histories for behavioral evidence. Search chat logs, git history, docs, and code for concrete examples of specific patterns, values, or skills.",
   "author": {
     "name": "Cory King",

--- a/project-mining/pyproject.toml
+++ b/project-mining/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-explorer"
-version = "1.29.0"
+version = "1.30.0"
 description = "MCP server for exploring Claude Code chat history — search conversations, quote moments, inspect subagents."
 requires-python = ">=3.11"
 dependencies = [

--- a/project-mining/skills/project-mining/SKILL.md
+++ b/project-mining/skills/project-mining/SKILL.md
@@ -83,7 +83,7 @@ The scout flags multi-human projects in its brief. During alignment, you name th
 
 This skill has two phases with a hard gate between them. **No dispatch until the plan is approved.** The planning phase is where all the quality leverage is — a good lens produces good findings almost mechanically; a bad lens produces padding no matter how good the researchers are.
 
-Start your first response with: `project-mining v2.32.1`
+Start your first response with: `project-mining v2.39.0`
 
 ### When to skip the topology entirely
 

--- a/project-mining/src/cc_explorer/mcp_server.py
+++ b/project-mining/src/cc_explorer/mcp_server.py
@@ -193,7 +193,7 @@ def list_project_sessions(
     min_agents: Annotated[
         int,
         Field(
-            description="Only sessions that spawned at least N subagents. Set min_agents=1 to find sessions that dispatched agents — the entry point to the agent-forensics tools (list_session_agents, get_agent_detail, audit_session_tools)."
+            description="Only sessions with at least N subagents in their full discovered population (`agents_present` — direct dispatches plus workflow-orchestrated orphans, NOT the top-down `agents` count). Set min_agents=1 to find every session that ran subagents, including workflow-only ones — the entry point to the agent-forensics tools (list_session_agents, get_agent_detail, audit_session_tools)."
         ),
     ] = 0,
     after: Annotated[
@@ -205,18 +205,18 @@ def list_project_sessions(
         Field(description="Only sessions before this datetime."),
     ] = None,
 ) -> SessionListResponse:
-    """List conversations in a project with stats: dates, message counts, token usage, tool calls, agent dispatches.
+    """List conversations in a project with stats: dates, message counts, human prompts, token usage, tool calls, agent dispatches.
 
-    This is the orientation step — like `ls -la` on the project's chat history. Use it to see what exists before searching. Pass min_agents=1 to narrow to sessions that dispatched subagents — the starting point for agent forensics (then drill in with list_session_agents / get_agent_detail / audit_session_tools). The calling conversation, if present, is kept but flagged `is_current: true` so you can tell which row is the session you're in.
+    This is the orientation step — like `ls -la` on the project's chat history. Use it to see what exists before searching. Each row carries two agent counts: `agents` (dispatched directly) and `agents_present` (the full population including workflow orphans) — a gap between them means the session orchestrated workflows. `user_turns` (human prompts) against a high message/agent count flags a single prompt that fanned out into a long autonomous run. Pass min_agents=1 to narrow to sessions that ran subagents — the starting point for agent forensics (then drill in with list_session_agents / get_agent_detail / audit_session_tools). The calling conversation, if present, is kept but flagged `is_current: true` so you can tell which row is the session you're in.
     """
     proj = resolve_project(project)
-    sessions = load_sessions(proj)
+    sessions = load_sessions(proj, with_agents_present=True)
     if not sessions:
         raise ToolError(f"No conversations found for {proj}")
 
     sessions = [s for s in sessions if s.message_count >= min_messages]
     sessions = [s for s in sessions if s.stats.tool_use_count >= min_tools]
-    sessions = [s for s in sessions if s.stats.agent_count >= min_agents]
+    sessions = [s for s in sessions if s.agents_present >= min_agents]
     sessions = _filter_by_date(sessions, after, before)
 
     if not sessions:

--- a/project-mining/src/cc_explorer/responses.py
+++ b/project-mining/src/cc_explorer/responses.py
@@ -53,8 +53,10 @@ class SessionSummary(SparseModel):
         default=None,
         description="Git worktree name this session lived in. Absent for the main worktree; present (e.g. 'happy-lehmann') for linked worktrees, which includes Claude Desktop dispatched sessions under `.claude-worktrees/`. Labeled sessions are often programmatically dispatched rather than interactively typed — calibrate signal accordingly.",
     )
-    messages: int = Field(description="Total message count.")
-    agents: int = Field(description="Number of subagent dispatches.")
+    messages: int = Field(description="Total message count (human + assistant turns).")
+    user_turns: int = Field(description="Human prompts — how many times the user actually spoke. A small number against many agents or messages flags a single prompt that fanned out into a long autonomous run.")
+    agents: int = Field(description="Subagents dispatched directly by the parent transcript (Task/Agent/TaskCreate blocks). Top-down view — does NOT count workflow-orchestrated agents.")
+    agents_present: int = Field(description="Full discovered subagent population — direct dispatches plus on-disk orphans (notably workflow-orchestrated agents). Matches list_session_agents' total_agents. When this exceeds `agents`, the session ran workflows. The min_agents filter matches on this number.")
     context_tokens: int = Field(description="Last assistant turn's input tokens (context window size).")
     output_tokens: int = Field(description="Total output tokens across all turns.")
     tools: int = Field(description="Total tool_use invocations.")
@@ -71,7 +73,9 @@ class SessionSummary(SparseModel):
             title=s.title,
             worktree=s.worktree,
             messages=s.message_count,
+            user_turns=s.user_turns,
             agents=s.stats.agent_count,
+            agents_present=s.agents_present,
             context_tokens=s.stats.context_tokens,
             output_tokens=s.stats.output_tokens,
             tools=s.stats.tool_use_count,

--- a/project-mining/src/cc_explorer/search.py
+++ b/project-mining/src/cc_explorer/search.py
@@ -26,6 +26,7 @@ from .models import (
 )
 from .formatting import _match_example
 from .parser import load_conversations, load_transcript
+from .subagents import discover_subagents
 from .utils import PrefixId, smart_truncate
 
 
@@ -128,6 +129,14 @@ class SessionInfo:
     message_count: int
     stats: TranscriptStats = field(default_factory=TranscriptStats)
     worktree: Optional[str] = None
+    # Number of human prompts (entries where the user actually spoke), distinct
+    # from message_count which also counts assistant turns. Signals how much the
+    # human drove the session vs one prompt fanning out into a long agent run.
+    user_turns: int = 0
+    # Full discovered subagent population — parent dispatches plus on-disk
+    # orphans (notably workflow-orchestrated agents). Equals list_session_agents'
+    # total_agents, unlike stats.agent_count which is top-down dispatches only.
+    agents_present: int = 0
 
 
 @dataclass
@@ -222,10 +231,18 @@ def session_title(entries: list[TranscriptEntry]) -> str:
     return "(empty session)"
 
 
-def load_sessions(project_path: str) -> list[SessionInfo]:
+def load_sessions(
+    project_path: str, *, with_agents_present: bool = False
+) -> list[SessionInfo]:
     """Find and load all conversation sessions for a project.
 
     Returns SessionInfo list sorted by first_timestamp (newest first).
+
+    `with_agents_present` populates SessionInfo.agents_present by walking each
+    session's on-disk subagents dir (reconciled against parent dispatches). That
+    walk is per-session filesystem I/O, so it's opt-in — only list_project_sessions,
+    which displays and filters on the count, needs it. Every other tool loads
+    sessions purely for their transcripts and leaves agents_present at 0.
     """
     conversations = load_conversations(project_path)
     sessions: list[SessionInfo] = []
@@ -245,6 +262,13 @@ def load_sessions(project_path: str) -> list[SessionInfo]:
         if message_count == 0:
             continue
 
+        # Human prompts only — how many times the user actually spoke.
+        user_turns = sum(
+            1
+            for e in entries
+            if isinstance(e, HumanEntry) and len(e.display(truncate=0)) > 0
+        )
+
         # Find first timestamp from any entry that has one (typed access)
         first_ts: Optional[datetime] = None
         for e in entries:
@@ -254,6 +278,15 @@ def load_sessions(project_path: str) -> list[SessionInfo]:
 
         title = session_title(entries)
         stats = TranscriptStats.from_entries(entries)
+        # Reconcile parent dispatches with the on-disk subagent walk so the
+        # count matches list_session_agents and catches workflow orphans. Reuses
+        # the already-parsed entries — only the tiny subagents/ dir is walked.
+        # Gated: most tools don't need it and shouldn't pay the per-session walk.
+        agents_present = (
+            len(discover_subagents(ref.path, entries=entries))
+            if with_agents_present
+            else 0
+        )
         sessions.append(
             SessionInfo(
                 session_id=session_id,
@@ -263,6 +296,8 @@ def load_sessions(project_path: str) -> list[SessionInfo]:
                 message_count=message_count,
                 stats=stats,
                 worktree=ref.worktree,
+                user_turns=user_turns,
+                agents_present=agents_present,
             )
         )
 

--- a/project-mining/src/cc_explorer/subagents.py
+++ b/project-mining/src/cc_explorer/subagents.py
@@ -126,11 +126,22 @@ def _parse_agent_spawn(
 
 
 def extract_subagents(transcript_path: Path) -> list[SubagentInfo]:
-    """Parse a session transcript and extract all agent tool spawns with results.
+    """Load a session transcript and extract its agent tool spawns.
 
-    Uses typed transcript entries from load_transcript(). Detects three tool
-    names: Agent (current), Task (older, same shape), and TaskCreate
-    (background task API, different fields).
+    Thin wrapper over extract_subagents_from_entries — call that directly when
+    the transcript is already parsed (e.g. the orientation hot path) to avoid
+    re-reading the file.
+    """
+    return extract_subagents_from_entries(load_transcript(transcript_path))
+
+
+def extract_subagents_from_entries(
+    entries: list[TranscriptEntry],
+) -> list[SubagentInfo]:
+    """Extract all agent tool spawns with results from parsed transcript entries.
+
+    Detects three tool names: Agent (current), Task (older, same shape), and
+    TaskCreate (background task API, different fields).
 
     Handles three result patterns:
     1. Sync completed — toolUseResult dict with status=completed, full stats
@@ -140,8 +151,6 @@ def extract_subagents(transcript_path: Path) -> list[SubagentInfo]:
 
     Returns SubagentInfo list ordered by appearance in the transcript.
     """
-    entries = load_transcript(transcript_path)
-
     spawns: dict[str, SubagentInfo] = {}  # keyed by tool_use_id
     spawn_order: list[str] = []
     # Reverse lookup: agentId -> tool_use_id (for task-notification matching)
@@ -338,7 +347,10 @@ def _attach_transcript_file(info: SubagentInfo, path: Path) -> None:
         info.output_file_exists = False
 
 
-def discover_subagents(session_path: Path) -> list[SubagentInfo]:
+def discover_subagents(
+    session_path: Path,
+    entries: Optional[list[TranscriptEntry]] = None,
+) -> list[SubagentInfo]:
     """Full subagent population for a session: parent dispatches + orphan files.
 
     Reconciles the top-down dispatch graph (extract_subagents) with the
@@ -356,8 +368,15 @@ def discover_subagents(session_path: Path) -> list[SubagentInfo]:
 
     Dispatched/dispatch_only entries preserve parent transcript order; orphans
     follow, ordered by filename.
+
+    Pass `entries` when the parent transcript is already parsed (the orientation
+    hot path) to skip re-reading it; otherwise the session file is loaded.
     """
-    dispatched = extract_subagents(session_path)
+    dispatched = (
+        extract_subagents_from_entries(entries)
+        if entries is not None
+        else extract_subagents(session_path)
+    )
     files = collect_agent_files(resolve_subagents_dir(session_path))
 
     by_tool_use: dict[str, SubagentInfo] = {}

--- a/project-mining/tests/test_discover_subagents.py
+++ b/project-mining/tests/test_discover_subagents.py
@@ -16,7 +16,10 @@ orphan transcripts — notably workflow-orchestrated agents under
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
+from cc_explorer.parser import ConversationRef, load_transcript
+from cc_explorer.search import load_sessions
 from cc_explorer.subagents import (
     AgentFile,
     collect_agent_files,
@@ -235,3 +238,104 @@ def test_discover_dispatch_only_has_no_file(tmp_path):
     ghost = next(a for a in agents if a.source == "dispatch_only")
     assert not ghost.output_file_exists
     assert ghost.tool_use_id == "toolu_NOFILE"
+
+
+def test_discover_from_preloaded_entries_matches_path_form(tmp_path):
+    """Passing entries (the orientation hot path) yields the identical population
+    as letting discover_subagents re-read the transcript itself."""
+    session = _setup_session(tmp_path)
+    from_path = discover_subagents(session)
+    from_entries = discover_subagents(session, entries=load_transcript(session))
+
+    assert len(from_path) == len(from_entries)
+    assert [a.source for a in from_path] == [a.source for a in from_entries]
+    assert [a.agent_id for a in from_path] == [a.agent_id for a in from_entries]
+
+
+# =============================================================================
+# Orientation count: load_sessions surfaces the present population
+# =============================================================================
+
+
+def _parent_chat() -> list[dict]:
+    """A parent transcript that dispatches NO agents directly — one human prompt,
+    one assistant reply. Stands in for a session that orchestrates only via a
+    Workflow (whose children land on disk but never as Task/Agent blocks)."""
+    return [
+        {
+            "type": "user",
+            "uuid": "u-root",
+            "timestamp": TS,
+            "sessionId": SID,
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "kick off the workflow"}],
+            },
+        },
+        {
+            "type": "assistant",
+            "uuid": "a-root",
+            "timestamp": TS,
+            "sessionId": SID,
+            "message": {
+                "id": "m0",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-opus-4",
+                "content": [{"type": "text", "text": "running it"}],
+            },
+        },
+    ]
+
+
+def _setup_workflow_only_session(tmp_path, n: int = 3) -> Path:
+    session = tmp_path / f"{SID}.jsonl"
+    _write_jsonl(session, _parent_chat())
+    subdir = tmp_path / SID / "subagents"
+    for i in range(1, n + 1):
+        f = subdir / "workflows" / "wf_run1" / f"agent-aid_wf{i}.jsonl"
+        _write_jsonl(f, _agent_transcript(f"aid_wf{i}", f"prompt {i}", f"result {i}"))
+        _meta(f, agentType="workflow-subagent")
+    return session
+
+
+def test_load_sessions_counts_workflow_orphans_as_present(tmp_path):
+    """The orphan-blind-spot fix: a workflow-only session has agent_count==0
+    top-down, but agents_present reflects the on-disk population so min_agents
+    no longer gates it out. user_turns counts the single human prompt."""
+    session = _setup_workflow_only_session(tmp_path, n=3)
+    conversations = {SID: ConversationRef(path=session, worktree=None)}
+    with patch("cc_explorer.search.load_conversations", return_value=conversations):
+        sessions = load_sessions(str(tmp_path), with_agents_present=True)
+
+    assert len(sessions) == 1
+    s = sessions[0]
+    assert s.stats.agent_count == 0  # nothing dispatched top-down
+    assert s.agents_present == 3  # all three workflow orphans discovered
+    assert s.user_turns == 1  # one human prompt, despite the fan-out
+
+
+def test_load_sessions_present_matches_discover(tmp_path):
+    """agents_present is exactly len(discover_subagents) so list_project_sessions
+    and list_session_agents can never disagree on the count."""
+    session = _setup_session(tmp_path)  # 1 dispatched + 1 dispatch_only + 1 orphan
+    conversations = {SID: ConversationRef(path=session, worktree=None)}
+    with patch("cc_explorer.search.load_conversations", return_value=conversations):
+        sessions = load_sessions(str(tmp_path), with_agents_present=True)
+
+    assert sessions[0].agents_present == len(discover_subagents(session))
+    assert sessions[0].agents_present == 3
+
+
+def test_load_sessions_skips_subagent_walk_by_default(tmp_path):
+    """agents_present is opt-in: tools that only need transcripts (read_turn,
+    grep_session, search_project, ...) must not pay the per-session subagents
+    walk. Default leaves the count at 0 without touching the filesystem tree."""
+    session = _setup_workflow_only_session(tmp_path, n=3)
+    conversations = {SID: ConversationRef(path=session, worktree=None)}
+    with patch("cc_explorer.search.load_conversations", return_value=conversations):
+        with patch("cc_explorer.search.discover_subagents") as walk:
+            sessions = load_sessions(str(tmp_path))
+
+    walk.assert_not_called()
+    assert sessions[0].agents_present == 0

--- a/project-mining/uv.lock
+++ b/project-mining/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "cc-explorer"
-version = "1.29.0"
+version = "1.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Closes #18.

## Problem

`list_project_sessions` counted agents **top-down** (`stats.agent_count` = `Task`/`Agent`/`TaskCreate` blocks in the parent transcript), while the #17 forensics tools went **bottom-up** via `discover_subagents`. The two diverged:

- **Display:** a workflow-heavy session showed `agents: 31` here but `total_agents: 104` in `list_session_agents`.
- **Discovery blind spot (the real bug):** a session whose subagents were *all* workflow-orchestrated had `agent_count == 0`, so `min_agents=1` filtered it out — yet every docstring points users to `list_project_sessions(min_agents=1)` as the forensics entry point.

## Changes

- Split `extract_subagents(path)` → `extract_subagents_from_entries(entries)` + thin wrapper; `discover_subagents(path, entries=None)` reuses already-parsed entries, so the orientation count adds **no second parse** of the parent transcript.
- `SessionInfo` / `SessionSummary` gain **two numbers**:
  - `agents` — dispatched directly (top-down, unchanged meaning).
  - `agents_present` — full discovered population (== `list_session_agents`' `total_agents`). A gap between them means the session orchestrated workflows.
- Also added `user_turns` (human prompt count) — distinguishes a 1-prompt fan-out from a long interactive session.
- `min_agents` now filters on `agents_present` (strictly more inclusive, since `agents_present >= agent_count`), so workflow-only sessions stop being gated out.

## Performance

The per-session `subagents/` filesystem walk is **opt-in** (`load_sessions(..., with_agents_present=True)`). Only `list_project_sessions` pays it; the 8 other tools that share `load_sessions` purely for transcripts (read_turn, grep_session, search_project, …) keep their cheap path. Caught and fixed during self-review.

## Tests

178 passing (+4): entries/path parity, workflow-only session counted as present (the blind-spot repro), `agents_present == len(discover_subagents)`, and a gate test pinning that the walk is skipped by default.

Versions bumped: plugin `2.39.0`, cc-explorer `1.30.0`, project-mining banner `v2.39.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)