### PR TITLE
fix(project-mining): register activity-analyst agent + activity-reflection skill

### DIFF
--- a/project-mining/.claude-plugin/plugin.json
+++ b/project-mining/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-mining",
-  "version": "2.42.0",
+  "version": "2.43.0",
   "description": "Mine project histories for behavioral evidence. Search chat logs, git history, docs, and code for concrete examples of specific patterns, values, or skills.",
   "author": {
     "name": "Cory King",
@@ -16,9 +16,10 @@
     "./agents/codebase-analyst.md",
     "./agents/output-analyst.md",
     "./agents/process-analyst.md",
-    "./agents/mining-researcher.md"
+    "./agents/mining-researcher.md",
+    "./agents/activity-analyst.md"
   ],
-  "skills": ["./skills/cc-explorer", "./skills/project-mining"],
+  "skills": ["./skills/cc-explorer", "./skills/project-mining", "./skills/activity-reflection"],
   "mcpServers": {
     "cc-explorer": {
       "command": "uv",

--- a/project-mining/pyproject.toml
+++ b/project-mining/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-explorer"
-version = "1.33.0"
+version = "1.34.0"
 description = "MCP server for exploring Claude Code chat history — search conversations, quote moments, inspect subagents."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Problem

Field-tested in a bluetaka session (`e4302a22`, ~15 min before this PR): the `activity-reflection` skill tried to dispatch `subagent_type: "project-mining:activity-analyst"`, but Claude Code couldn't find that agent type. The main thread worked around it by `Read`-ing `activity-analyst.md` out of the plugin cache and pasting it into a **`general-purpose`** agent:

```
Agent({ subagent_type: 'general-purpose', name: 'activity-analyst',
        prompt: 'You are operating under the following agent definition ... # Activity Analyst ...' })
```

i.e. a synthetic stand-in for the real, unregistered agent — running on the wrong tier (no `model: opus` from the frontmatter) and outside the registered-agent contract.

## Root cause

#26 added `agents/activity-analyst.md` and `skills/activity-reflection/SKILL.md` but never added them to `plugin.json`'s `agents`/`skills` arrays, so neither was registered with Claude Code.

## Fix

- Register `./agents/activity-analyst.md` and `./skills/activity-reflection` in the manifest.
- Bump `project-mining` 2.42.0 → 2.43.0 and `cc-explorer` 1.33.0 → 1.34.0 so Claude Code reloads.

No code change — the skill already dispatches the correct namespaced type; it just had nothing to resolve to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)