### PR TITLE
feat(cc-explorer): convert_session + delete_conversions — session ↔ subagent converter (#29)

### DIFF
--- a/project-mining/.claude-plugin/plugin.json
+++ b/project-mining/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-mining",
-  "version": "2.43.0",
+  "version": "2.44.0",
   "description": "Mine project histories for behavioral evidence. Search chat logs, git history, docs, and code for concrete examples of specific patterns, values, or skills.",
   "author": {
     "name": "Cory King",

--- a/project-mining/pyproject.toml
+++ b/project-mining/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-explorer"
-version = "1.34.0"
+version = "1.35.0"
 description = "MCP server for exploring Claude Code chat history — search conversations, quote moments, inspect subagents."
 requires-python = ">=3.11"
 dependencies = [

--- a/project-mining/skills/cc-explorer/SKILL.md
+++ b/project-mining/skills/cc-explorer/SKILL.md
@@ -5,7 +5,8 @@ description: >
   find what was discussed, trace subagent execution, inspect what an agent did, or browse chat logs.
   Triggers on: "search my chats", "what did that agent do", "trace that session", "look at my
   conversations", "check my chat history", "find where we talked about X", "which sessions used
-  agents". Do NOT use for behavioral evidence mining or resume work — that's the project-mining skill.
+  agents", "ask a past session", "convert a session into a subagent", "question that old conversation".
+  Do NOT use for behavioral evidence mining or resume work — that's the project-mining skill.
 ---
 
 # cc-explorer
@@ -57,6 +58,19 @@ Tools for tracing subagent execution — a separate axis from conversation conte
 
 Use when tracing what an agent did, correlating outputs with sessions, or building timelines that distinguish "discussed doing X" from "dispatched agents to do X."
 
+## The conversion tools
+
+Tools that create new transcripts — the one mutating axis in the toolset. Both only ever copy; no existing session or subagent is modified.
+
+- **`convert_session`** — copy a session into a subagent under the calling session (direction `session_to_subagent`), or a subagent out to a top-level session (direction `subagent_to_session`).
+- **`delete_conversions`** — remove subagent artifacts the converter created. Refuses everything else, including converted sessions. Permanent — no undo.
+
+Convert a session to a subagent when the question needs the session itself, not excerpts from it: the reasoning behind a decision, a synthesis of the whole arc, a judgment call on evidence it hasn't seen, or a domain expert whose built-up context would be expensive to rebuild. Resume the new agent with `SendMessage(to: <created_id>)`; its reply is its final message; message it again to follow up. For facts, quotes, locations, and tool-call ground truth, stay on the read tools.
+
+First message to a converted conversation: open with the `suggested_handoff` from the tool response — the conversation has no way to know its interlocutor changed, and nothing on the wire tells it. Then say who you are and what you want. Offer your reading of the session as a reading, not a fact — you have excerpts, it has the whole conversation; let it correct you. If the answer should account for the present, brief it on what changed after the session ended. Relay `environment` facts from the response only when the ask depends on them (e.g. it will run tools in a cwd it doesn't remember).
+
+Convert a subagent to a session when the user wants to read or continue an agent's run themselves — hand them the `claude -r` command from the response.
+
 ## Worktree pooling
 
 Sessions from every git worktree of a project are pooled under one project — and this holds cross-project too: `list_projects` and an omitted-`projects` search show one row per repo, not one per worktree. Claude Desktop dispatch creates real git worktrees under `<project>/.claude-worktrees/<name>/`, so dispatched work shows up alongside interactive sessions automatically — no need to specify a worktree or know which branch work happened on.
@@ -74,6 +88,8 @@ Each session carries a `worktree` field (absent for the main worktree, set to th
 **"Show me what was said"** → `grep_session` for pattern-matched content with context, or `read_turn` to read a specific moment at full fidelity. Use `full_length` values in grep output to gauge entry size before reading.
 
 **"Trace agent execution"** → `list_project_sessions(min_agents=1)` → `list_session_agents` → `get_agent_detail` (or `audit_session_tools` for the whole-session tool-usage view). Top-down zoom from project to session to individual agent.
+
+**"Why did that session decide X? What did it learn?"** → `convert_session`, then `SendMessage`. Grep finds what was said; a converted session can answer for what it meant.
 
 ## Key workflows
 
@@ -99,3 +115,4 @@ Trace subagent execution top-down: `list_project_sessions(min_agents=1)` identif
 - `full_length` in grep output tells you how big an entry is before you read it. Large values (5000+) mean tool results or long outputs — use `read_turn` with a `limit` to avoid pulling in too much.
 - High agent counts in session listings signal orchestration sessions (fan-out research, multi-step workflows).
 - Search is exhaustive by default — patterns match against text, tool inputs (Bash commands, file paths, grep patterns), tool outputs, and assistant thinking. Write tight regex to narrow noisy searches.
+- Converted conversations push back on wrong premises rather than play along — but offer your understanding as understanding anyway; don't make them fight a frame you asserted as fact.

--- a/project-mining/skills/cc-explorer/SKILL.md
+++ b/project-mining/skills/cc-explorer/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Triggers on: "search my chats", "what did that agent do", "trace that session", "look at my
   conversations", "check my chat history", "find where we talked about X", "which sessions used
   agents", "ask a past session", "convert a session into a subagent", "question that old conversation".
-  Do NOT use for behavioral evidence mining or resume work — that's the project-mining skill.
+  Do NOT use for behavioral evidence mining or evidence-document work — that's the project-mining skill.
 ---
 
 # cc-explorer
@@ -67,9 +67,15 @@ Tools that create new transcripts — the one mutating axis in the toolset. Both
 
 Convert a session to a subagent when the question needs the session itself, not excerpts from it: the reasoning behind a decision, a synthesis of the whole arc, a judgment call on evidence it hasn't seen, or a domain expert whose built-up context would be expensive to rebuild. Resume the new agent with `SendMessage(to: <created_id>)`; its reply is its final message; message it again to follow up. For facts, quotes, locations, and tool-call ground truth, stay on the read tools.
 
-First message to a converted conversation: open with the `suggested_handoff` from the tool response — the conversation has no way to know its interlocutor changed, and nothing on the wire tells it. Then say who you are and what you want. Offer your reading of the session as a reading, not a fact — you have excerpts, it has the whole conversation; let it correct you. If the answer should account for the present, brief it on what changed after the session ended. Relay `environment` facts from the response only when the ask depends on them (e.g. it will run tools in a cwd it doesn't remember).
-
 Convert a subagent to a session when the user wants to read or continue an agent's run themselves — hand them the `claude -r` command from the response.
+
+### Composing the first message to a converted conversation
+
+Open with the `suggested_handoff` from the tool response. The conversation has no way to know its interlocutor changed — messages arrive unlabeled, and you occupy the same `user` role its human did — so the handoff's one job is to resolve the contradiction between its runtime ("you are a subagent") and its history (an interactive session, mid-relationship with someone else). Then say who you are and what you want, in whatever role fits the intent: witness, fact-checker, expert consult, plain continuation. The framing controls stance, not correctness — without one, the conversation defaults to being its old user's assistant and offers to resume the relationship.
+
+Mind the knowledge asymmetry (the emic/etic gap): you've read excerpts from the outside; it lived the whole thing and is the authority on what its conversation was about. Offer your reading as a reading — "my understanding from the outside is this session was about X; correct me if that's off" — never as established fact. A presupposed frame invites it to elaborate your guess instead of reporting its reality, and when the premise is flat wrong it has to spend its whole answer fighting the frame. Converted conversations do push back rather than play along — but don't bet on that against a confidently-asserted wrong premise.
+
+Its knowledge ends where the conversation ended. If the answer should account for the present, brief it on what changed first, then ask for the judgment. Relay `environment` facts from the response only when the ask depends on them — e.g. it will run tools in a cwd it doesn't remember having left.
 
 ## Worktree pooling
 

--- a/project-mining/src/cc_explorer/activity.py
+++ b/project-mining/src/cc_explorer/activity.py
@@ -288,8 +288,12 @@ def build_activity_timeline(
 
             # Fold subagents: their agent activity unions into the parent, their
             # internal human turns become parent agent work, their turn_min adds.
+            # Conversion artifacts are skipped — they preserve original timestamps
+            # and would double-count the source's history as the parent's agent activity.
             n_sub = 0
             for af in collect_agent_files(resolve_subagents_dir(ref.path)):
+                if af.is_conversion_artifact:
+                    continue
                 cs = _scan(af.path, lo, hi, bucket_s)
                 if cs is None or not _has_activity(cs):
                     continue

--- a/project-mining/src/cc_explorer/conversion.py
+++ b/project-mining/src/cc_explorer/conversion.py
@@ -202,9 +202,38 @@ def _line_text(line: dict[str, Any]) -> str:
     return ""
 
 
+def _content_has_non_text_block(line: dict[str, Any]) -> bool:
+    """True when message.content is a list containing ANY non-text block.
+
+    A user turn whose content includes tool_result, image, or other non-text
+    blocks carries semantic meaning even if the text blocks are empty — it must
+    never be trimmed as trailing noise.
+    """
+    msg = line.get("message")
+    if not isinstance(msg, dict):
+        return False
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return False
+    return any(
+        isinstance(b, dict) and b.get("type") != "text"
+        for b in content
+    )
+
+
 def _is_trailing_noise(line: dict[str, Any]) -> bool:
-    """True when a trailing user line is empty / interrupt / command scaffolding."""
+    """True when a trailing user line is empty / interrupt / command scaffolding.
+
+    A user line whose content list contains ANY non-text block (tool_result,
+    image, etc.) is NEVER trailing noise — only lines whose content is entirely
+    text (or an empty string) qualify. Without this guard a tool_result-only
+    user turn reads as empty text and gets trimmed, leaving a dangling assistant
+    tool_use that the API rejects on resume.
+    """
     if line.get("type") != "user":
+        return False
+    # If the content has any non-text blocks, preserve the line unconditionally.
+    if _content_has_non_text_block(line):
         return False
     text = _line_text(line).strip()
     if not text:
@@ -259,6 +288,87 @@ def _prior_converted_from(raw: list[dict[str, Any]]) -> Optional[dict[str, Any]]
         if isinstance(cf, dict):
             return cf
     return None
+
+
+def _extract_active_thread(
+    lines: list[dict[str, Any]],
+    *,
+    drop_sidechain: bool = False,
+) -> tuple[list[dict[str, Any]], int]:
+    """Return (active_chain, dropped_count) for the active conversation thread.
+
+    Algorithm: take the LAST user/assistant line in file order as the tip (after
+    optionally dropping isSidechain lines for session_to_subagent), walk
+    parentUuid links backward to the root, keep exactly that chain in
+    root→tip order. Lines not on the chain (abandoned edit-branches, embedded
+    sidechain turns) are dropped.
+
+    `drop_sidechain=True` (session_to_subagent only): drop lines with truthy
+    `isSidechain` BEFORE picking the tip — they are embedded subagent turns from
+    the old format, not main-thread lines. Do NOT set this for subagent sources
+    where every line is isSidechain=True.
+
+    Fallback: if the parentUuid walk breaks (missing parent, cycle, or all lines
+    lack parentUuid — e.g. synthetic transcripts), return lines as-is with 0
+    dropped so file-order behavior is preserved.
+    """
+    candidates = list(lines)
+    if drop_sidechain:
+        candidates = [d for d in candidates if not d.get("isSidechain")]
+
+    if not candidates:
+        return lines, 0
+
+    # Index by uuid for O(1) parent lookup.
+    by_uuid: dict[str, dict[str, Any]] = {}
+    for d in candidates:
+        u = d.get("uuid")
+        if u:
+            by_uuid[u] = d
+
+    # If no line has a uuid at all → synthetic transcript; fall back.
+    if not by_uuid:
+        return lines, 0
+
+    # The canonical root is the FIRST candidate in file order; only parentUuid=null
+    # on that node is a real root — null on any later node means the link is absent
+    # (e.g. synthetic test fixtures that didn't wire parentUuid forward), which is
+    # the "missing parent link" fallback case.
+    first_uuid = candidates[0].get("uuid") if candidates else None
+
+    # Tip: last candidate in file order.
+    tip = candidates[-1]
+
+    # Walk parentUuid links to build the chain.
+    chain: list[dict[str, Any]] = []
+    visited: set[str] = set()
+    current: Optional[dict[str, Any]] = tip
+    while current is not None:
+        uid = current.get("uuid")
+        if uid:
+            if uid in visited:
+                # Cycle — fall back to file order.
+                return lines, 0
+            visited.add(uid)
+        chain.append(current)
+        parent_uuid = current.get("parentUuid")
+        if not parent_uuid:
+            # Null parentUuid: real root only if this is the first file-order node.
+            if uid and uid != first_uuid:
+                # Non-first node with null parent → missing link; fall back.
+                return lines, 0
+            break  # genuine root
+        parent = by_uuid.get(parent_uuid)
+        if parent is None:
+            # Missing parent link — fall back.
+            return lines, 0
+        current = parent
+
+    chain.reverse()  # root → tip order
+
+    kept_set = {id(d) for d in chain}
+    dropped = sum(1 for d in lines if id(d) not in kept_set)
+    return chain, dropped
 
 
 def _relinearize(lines: list[dict[str, Any]]) -> None:
@@ -412,6 +522,7 @@ class ConversionResult:
     environment: dict[str, Any]
     lineage: list[dict[str, str]]
     nested_agents: int = 0
+    dropped_branches: int = 0
     # session_to_subagent
     parent_session: Optional[str] = None
     suggested_handoff: Optional[str] = None
@@ -446,9 +557,13 @@ def convert_session_to_subagent(
     reported so the caller knows context was folded in.
     """
     raw = _read_raw_lines(src_path)
-    lines = _keep_convo_lines(raw)
+    all_lines = _keep_convo_lines(raw)
     prior = _prior_lineage(raw)
     src_converted_from = _prior_converted_from(raw)
+
+    # For session_to_subagent: drop isSidechain lines (embedded subagent turns
+    # from the old format) before picking the active thread tip.
+    lines, dropped_branches = _extract_active_thread(all_lines, drop_sidechain=True)
 
     new_agent = _new_agent_id()
 
@@ -476,6 +591,7 @@ def convert_session_to_subagent(
         "id": src_session_id,
         "project": src_project_path,
     }
+    # Stamp provenance keys in the existing mutation loop (no second pass).
     for d in lines:
         d["_converted_from"] = converted_from
         d["_lineage"] = lineage
@@ -495,8 +611,10 @@ def convert_session_to_subagent(
         agent_id=new_agent,
         lines_at_creation=len(lines) + 1,
     )
+    # Write provenance line then body sequentially (no list concat).
     with open(out_path, "w", encoding="utf-8") as f:
-        for d in [provenance_line] + lines:
+        f.write(json.dumps(provenance_line) + "\n")
+        for d in lines:
             f.write(json.dumps(d) + "\n")
 
     src8 = src_session_id[:8]
@@ -518,6 +636,7 @@ def convert_session_to_subagent(
         created_id=new_agent,
         turns=len(lines),
         trimmed_trailing=trimmed,
+        dropped_branches=dropped_branches,
         tail_state=_tail_state(lines),
         models=_model_stats(lines),
         environment=_environment(lines),
@@ -591,19 +710,14 @@ def convert_subagent_to_session(
     sessionId. Refuses to overwrite an existing session file.
     """
     raw = _read_raw_lines(src_path)
-    lines = _keep_convo_lines(raw)
+    all_lines = _keep_convo_lines(raw)
     prior = _prior_lineage(raw)
 
+    # For subagent_to_session: do NOT drop sidechain lines — every line in a
+    # subagent transcript is isSidechain=True; dropping them would empty the body.
+    lines, dropped_branches = _extract_active_thread(all_lines, drop_sidechain=False)
+
     new_session = str(uuid.uuid4())
-
-    for d in lines:
-        for k in _STRIP_SUBAGENT_TO_SESSION:
-            d.pop(k, None)
-        d["isSidechain"] = False
-        d["sessionId"] = new_session
-
-    _relinearize(lines)
-    trimmed = _trim_trailing_noise(lines)
 
     lineage = list(prior) + [
         {"as": "subagent", "id": src_agent_id},
@@ -614,9 +728,17 @@ def convert_subagent_to_session(
         "id": src_agent_id,
         "project": src_project_path,
     }
+    # Stamp provenance keys and strip/set fields in one loop (no second pass).
     for d in lines:
+        for k in _STRIP_SUBAGENT_TO_SESSION:
+            d.pop(k, None)
+        d["isSidechain"] = False
+        d["sessionId"] = new_session
         d["_converted_from"] = converted_from
         d["_lineage"] = lineage
+
+    _relinearize(lines)
+    trimmed = _trim_trailing_noise(lines)
 
     header = [
         {"type": "mode", "mode": "normal", "sessionId": new_session},
@@ -637,7 +759,6 @@ def convert_subagent_to_session(
         agent_id=None,
         lines_at_creation=len(header) + 1 + len(lines),
     )
-    all_lines = header + [provenance_line] + lines
 
     out_path = dest_project_dir / f"{new_session}.jsonl"
     if out_path.exists():
@@ -645,8 +766,12 @@ def convert_subagent_to_session(
             f"Refusing to overwrite existing session file: {out_path}"
         )
     dest_project_dir.mkdir(parents=True, exist_ok=True)
+    # Write header, provenance, then body sequentially (no list concat).
     with open(out_path, "w", encoding="utf-8") as f:
-        for d in all_lines:
+        for d in header:
+            f.write(json.dumps(d) + "\n")
+        f.write(json.dumps(provenance_line) + "\n")
+        for d in lines:
             f.write(json.dumps(d) + "\n")
 
     return ConversionResult(
@@ -654,6 +779,7 @@ def convert_subagent_to_session(
         created_id=new_session,
         turns=len(lines),
         trimmed_trailing=trimmed,
+        dropped_branches=dropped_branches,
         tail_state=_tail_state(lines),
         models=_model_stats(lines),
         environment=_environment(lines),
@@ -669,7 +795,7 @@ def convert_subagent_to_session(
 # =============================================================================
 
 
-def is_conversion(transcript_path: Path) -> bool:
+def is_conversion_artifact(transcript_path: Path) -> bool:
     """True when a transcript carries a shape-valid x-converter-provenance line.
 
     The single trust signal for both directions: meta.json is no longer a trust

--- a/project-mining/src/cc_explorer/conversion.py
+++ b/project-mining/src/cc_explorer/conversion.py
@@ -1,0 +1,740 @@
+"""Session <-> subagent transcript conversion (always a COPY).
+
+This module reshapes Claude Code transcripts between two on-disk shapes:
+
+  - a top-level *session* transcript at ``<projectDir>/<sessionId>.jsonl``
+  - a *subagent* transcript at
+    ``<projectDir>/<parentSessionId>/subagents/agent-<agentId>.jsonl`` with a
+    sibling ``agent-<agentId>.meta.json``.
+
+The harness resolves a resume target by scanning these files on disk, so a
+correctly-shaped file IS a resumable agent (or session). Conversion never
+modifies, moves, or deletes the source — it reads the source transcript and
+writes a fresh copy in the other shape, stamping provenance keys
+(``_converted_from``, ``_lineage``) and a dedicated ``x-converter-provenance``
+line at the top of the written file so the artifact is identifiable and
+removable later (see delete_conversions).
+
+The ``x-converter-provenance`` line is the ONLY durable trust surface. A live
+durability probe showed the harness REWRITES an agent's ``meta.json`` on
+SendMessage-resume, preserving only ``agentType``/``description``/``toolUseId``
+and silently dropping any unknown keys — so a provenance key written into
+``meta.json`` vanishes on first resume. A custom own-type line in the jsonl body
+survives untouched. We therefore put the full sentinel (including
+``lines_at_creation``) on that line and key every downstream decision
+(search-corpus exclusion, agent labeling, deletion eligibility) off it.
+``meta.json`` carries only the standard three keys, with origin encoded in the
+human-readable ``description`` string.
+
+We operate on RAW JSONL dicts, not the typed `TranscriptEntry` models: the
+harness tolerates (and we must preserve) unknown envelope fields, and we add our
+own provenance keys that the typed models would drop. The typed layer is for
+reading; this is surgery on the wire format.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import uuid
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+# Conversation line types we copy. Everything else (system, summary, progress,
+# file-history-snapshot, queue-operation, mode/permission/custom-title headers)
+# is dropped from the body — a subagent/session transcript is a linear chain of
+# user/assistant turns; headers are re-synthesized where the target needs them.
+_CONVO_TYPES = ("user", "assistant")
+
+# The own-type provenance line stamped at the top of every conversion. This is
+# the single durable trust surface (meta.json is rewritten on resume; see module
+# docstring). `_PROVENANCE_VERSION` is the sentinel schema version.
+_PROVENANCE_TYPE = "x-converter-provenance"
+_PROVENANCE_VERSION = 1
+_CONVERTER_TOOL = "convert_session"
+
+# Keys stripped when copying a SESSION into a SUBAGENT.
+_STRIP_SESSION_TO_SUBAGENT = (
+    "forkedFrom",
+    "isMeta",
+    "attributionAgent",
+    "attributionSkill",
+    "sourceToolAssistantUUID",
+)
+
+# Keys stripped when copying a SUBAGENT into a SESSION.
+_STRIP_SUBAGENT_TO_SESSION = (
+    "agentId",
+    "attributionAgent",
+    "attributionSkill",
+    "sourceToolAssistantUUID",
+)
+
+# A trailing user turn matching any of these is conversational dead weight (an
+# unanswered prompt, an interrupt sentinel, or bare command scaffolding) and is
+# trimmed so the copy ends on a clean boundary.
+_TRAILING_NOISE_MARKERS = ("[Request interrupted", "<local-command", "<command-name>")
+
+
+def _new_agent_id() -> str:
+    """Mint a harness-shaped agent id: 'a' + 16 hex chars."""
+    return "a" + secrets.token_hex(8)
+
+
+def _new_tool_use_id() -> str:
+    """Mint a tool-use id shaped like the harness's: 'toolu_' + 24 hex chars."""
+    return "toolu_" + secrets.token_hex(12)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _provenance_line(
+    *,
+    src_kind: str,
+    src_id: str,
+    src_project: str,
+    session_id: Optional[str],
+    agent_id: Optional[str],
+    lines_at_creation: int,
+) -> dict[str, Any]:
+    """Build one x-converter-provenance line — the single durable trust surface.
+
+    `lines_at_creation` is the TOTAL physical line count of the file as written,
+    THIS provenance line included. `agent_id` is the new agent id for subagent
+    conversions, None for session conversions; `session_id` is the parent (subagent
+    conv) or the new session id (session conv).
+    """
+    return {
+        "type": _PROVENANCE_TYPE,
+        "x_converter": {
+            "tool": _CONVERTER_TOOL,
+            "v": _PROVENANCE_VERSION,
+            "from": {"kind": src_kind, "id": src_id, "project": src_project},
+            "converted_at": _now_iso(),
+            "lines_at_creation": lines_at_creation,
+        },
+        "sessionId": session_id,
+        "agentId": agent_id,
+    }
+
+
+def read_provenance(transcript_path: Path) -> Optional[dict[str, Any]]:
+    """Return the validated `x_converter` sentinel for a conversion, else None.
+
+    The provenance line is written at the top, so the fast path reads only the
+    head of the file. We scan a tiny window (provenance is line 1 for subagent
+    conversions, line 4 — right after the custom-title header — for session
+    conversions, with slack for hand-edits) rather than the whole file.
+
+    Shape-validates: the line must be an `x-converter-provenance` dict whose
+    `x_converter` is a dict carrying a `from` dict and an int `lines_at_creation`.
+    A line that merely names the type but is malformed returns None (it is not a
+    trustworthy conversion marker).
+    """
+    _SCAN_LIMIT = 8  # provenance is line 1 or 4; a tiny window absorbs reordering.
+    try:
+        with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
+            for i, line in enumerate(f):
+                if i >= _SCAN_LIMIT:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                if '"' + _PROVENANCE_TYPE + '"' not in line:
+                    continue
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(data, dict) or data.get("type") != _PROVENANCE_TYPE:
+                    continue
+                sentinel = data.get("x_converter")
+                if not isinstance(sentinel, dict):
+                    continue
+                if not isinstance(sentinel.get("from"), dict):
+                    continue
+                if not isinstance(sentinel.get("lines_at_creation"), int):
+                    continue
+                return sentinel
+    except OSError:
+        return None
+    return None
+
+
+def current_line_count(transcript_path: Path) -> int:
+    """Total non-blank-tolerant line count of a transcript (every physical line).
+
+    Counts physical lines exactly as `_write_with_provenance` did (it wrote one
+    line per dict), so this is directly comparable to `lines_at_creation` for the
+    growth guard. Blank lines are counted too — a resumed file that appended blank
+    lines still grew, and we refuse to delete grown files.
+    """
+    try:
+        with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
+            return sum(1 for _ in f)
+    except OSError:
+        return 0
+
+
+def _line_text(line: dict[str, Any]) -> str:
+    """Concatenated text of a user/assistant line's content blocks.
+
+    Handles both bare-string content and the block-list shape. Used only for
+    trailing-noise detection, so it is deliberately simple — no XML stripping.
+    """
+    msg = line.get("message")
+    if not isinstance(msg, dict):
+        return ""
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(
+            b.get("text", "")
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return ""
+
+
+def _is_trailing_noise(line: dict[str, Any]) -> bool:
+    """True when a trailing user line is empty / interrupt / command scaffolding."""
+    if line.get("type") != "user":
+        return False
+    text = _line_text(line).strip()
+    if not text:
+        return True
+    return any(marker in text for marker in _TRAILING_NOISE_MARKERS)
+
+
+def _read_raw_lines(path: Path) -> list[dict[str, Any]]:
+    """Read a JSONL transcript into raw dicts, skipping unparseable lines."""
+    out: list[dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(data, dict):
+                out.append(data)
+    return out
+
+
+def _keep_convo_lines(raw: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Keep only user/assistant lines that carry a dict message."""
+    return [
+        d
+        for d in raw
+        if d.get("type") in _CONVO_TYPES and isinstance(d.get("message"), dict)
+    ]
+
+
+def _prior_lineage(raw: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """The first `_lineage` breadcrumb found in the source, else []."""
+    for d in raw:
+        lin = d.get("_lineage")
+        if isinstance(lin, list):
+            return lin
+    return []
+
+
+def _prior_converted_from(raw: list[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    """The source's own `_converted_from` stamp, if it was itself a conversion.
+
+    Present when the source transcript was produced by an earlier conversion. Its
+    `kind` ('session' | 'subagent') says what the source was BEFORE that
+    conversion — used to phrase the handoff's origin sentence correctly.
+    """
+    for d in raw:
+        cf = d.get("_converted_from")
+        if isinstance(cf, dict):
+            return cf
+    return None
+
+
+def _relinearize(lines: list[dict[str, Any]]) -> None:
+    """Rewrite parentUuid into a linear chain in file order, in place.
+
+    First line gets parentUuid=null; each subsequent line points at the previous
+    line's uuid. Source transcripts are TREES (message edits create siblings); a
+    subagent/session transcript must be a linear chain, so we flatten. Every line
+    is guaranteed a uuid (minted if missing).
+    """
+    parent: Optional[str] = None
+    for d in lines:
+        u = d.get("uuid") or str(uuid.uuid4())
+        d["uuid"] = u
+        d["parentUuid"] = parent
+        parent = u
+
+
+def _trim_trailing_noise(lines: list[dict[str, Any]]) -> int:
+    """Drop trailing noise user turns in place. Returns the number trimmed."""
+    trimmed = 0
+    while lines and _is_trailing_noise(lines[-1]):
+        lines.pop()
+        trimmed += 1
+    return trimmed
+
+
+def _tail_state(lines: list[dict[str, Any]]) -> str:
+    """'clean' when the last kept line is assistant, else 'pending_user_input'."""
+    if lines and lines[-1].get("type") == "assistant":
+        return "clean"
+    return "pending_user_input"
+
+
+def _model_stats(lines: list[dict[str, Any]]) -> dict[str, Any]:
+    """{first, last, counts} over assistant-line message.model values."""
+    models: list[str] = []
+    for d in lines:
+        if d.get("type") != "assistant":
+            continue
+        msg = d.get("message")
+        if isinstance(msg, dict):
+            m = msg.get("model")
+            if isinstance(m, str) and m:
+                models.append(m)
+    counts = dict(Counter(models))
+    return {
+        "first": models[0] if models else None,
+        "last": models[-1] if models else None,
+        "counts": counts,
+    }
+
+
+def _environment(lines: list[dict[str, Any]]) -> dict[str, Any]:
+    """Original cwd / branch / version / last timestamp, with existence checks.
+
+    `branch_exists` is None when the cwd is gone or isn't a git repo (we can't
+    tell), True/False otherwise. `age_days` is whole days from the last
+    timestamp to now.
+    """
+    cwd = ""
+    branch = ""
+    version = ""
+    last_ts = ""
+    for d in lines:
+        if not cwd and isinstance(d.get("cwd"), str):
+            cwd = d["cwd"]
+        if not branch and isinstance(d.get("gitBranch"), str):
+            branch = d["gitBranch"]
+        if not version and isinstance(d.get("version"), str):
+            version = d["version"]
+        if isinstance(d.get("timestamp"), str):
+            last_ts = d["timestamp"]
+
+    cwd_exists = bool(cwd) and Path(cwd).is_dir()
+    branch_exists = _branch_exists(cwd, branch) if cwd_exists else None
+
+    age_days: Optional[int] = None
+    if last_ts:
+        try:
+            ts = datetime.fromisoformat(last_ts.replace("Z", "+00:00"))
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            age_days = (datetime.now(timezone.utc) - ts).days
+        except ValueError:
+            age_days = None
+
+    return {
+        "original_cwd": cwd or None,
+        "cwd_exists": cwd_exists,
+        "original_branch": branch or None,
+        "branch_exists": branch_exists,
+        "cc_version": version or None,
+        "last_timestamp": last_ts or None,
+        "age_days": age_days,
+    }
+
+
+def _branch_exists(cwd: str, branch: str) -> Optional[bool]:
+    """Whether `branch` is a valid ref in the repo at `cwd`. None if not a repo.
+
+    Guarded git shell-out — `rev-parse --verify` against the branch ref. Returns
+    None (not False) when cwd isn't a git repo, so the caller can distinguish
+    "branch gone" from "can't tell".
+    """
+    if not branch:
+        return None
+    import subprocess
+
+    try:
+        inside = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--is-inside-work-tree"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        return None
+
+    try:
+        verify = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return verify.returncode == 0
+
+
+# =============================================================================
+# Result objects
+# =============================================================================
+
+
+@dataclass
+class ConversionResult:
+    """The outcome of one conversion, carrying everything the tool surfaces."""
+
+    direction: str
+    created_id: str
+    turns: int
+    trimmed_trailing: int
+    tail_state: str
+    models: dict[str, Any]
+    environment: dict[str, Any]
+    lineage: list[dict[str, str]]
+    nested_agents: int = 0
+    # session_to_subagent
+    parent_session: Optional[str] = None
+    suggested_handoff: Optional[str] = None
+    # subagent_to_session
+    title: Optional[str] = None
+    project: Optional[str] = None
+    # written paths (for tests / deletion)
+    written_path: Optional[Path] = None
+    meta_path: Optional[Path] = None
+
+
+# =============================================================================
+# session_to_subagent
+# =============================================================================
+
+
+def convert_session_to_subagent(
+    *,
+    src_session_id: str,
+    src_path: Path,
+    src_project_path: str,
+    dest_parent_session_id: str,
+    dest_parent_session_dir: Path,
+    nested_agents: int = 0,
+) -> ConversionResult:
+    """Copy a session transcript into a new subagent under a parent session.
+
+    `dest_parent_session_dir` is ``<projectDir>/<parentSessionId>`` — the new
+    ``subagents/agent-<id>.jsonl`` and its meta sidecar are written under it.
+    `nested_agents` is the count of subagents the SOURCE session itself ran; they
+    are not copied (their results already appear inline), but the count is
+    reported so the caller knows context was folded in.
+    """
+    raw = _read_raw_lines(src_path)
+    lines = _keep_convo_lines(raw)
+    prior = _prior_lineage(raw)
+    src_converted_from = _prior_converted_from(raw)
+
+    new_agent = _new_agent_id()
+
+    for d in lines:
+        for k in _STRIP_SESSION_TO_SUBAGENT:
+            d.pop(k, None)
+        d["isSidechain"] = True
+        d["agentId"] = new_agent
+        d["sessionId"] = dest_parent_session_id
+
+    _relinearize(lines)
+
+    # The first line of a resumable subagent needs a promptId.
+    if lines and not lines[0].get("promptId"):
+        lines[0]["promptId"] = str(uuid.uuid4())
+
+    trimmed = _trim_trailing_noise(lines)
+
+    lineage = list(prior) + [
+        {"as": "session", "id": src_session_id},
+        {"as": "subagent", "id": new_agent},
+    ]
+    converted_from = {
+        "kind": "session",
+        "id": src_session_id,
+        "project": src_project_path,
+    }
+    for d in lines:
+        d["_converted_from"] = converted_from
+        d["_lineage"] = lineage
+
+    subagents_dir = dest_parent_session_dir / "subagents"
+    subagents_dir.mkdir(parents=True, exist_ok=True)
+    out_path = subagents_dir / f"agent-{new_agent}.jsonl"
+    meta_path = subagents_dir / f"agent-{new_agent}.meta.json"
+
+    # The x-converter-provenance line (line 1) is the only durable trust surface.
+    # lines_at_creation counts the whole file (provenance line + body).
+    provenance_line = _provenance_line(
+        src_kind="session",
+        src_id=src_session_id,
+        src_project=src_project_path,
+        session_id=dest_parent_session_id,
+        agent_id=new_agent,
+        lines_at_creation=len(lines) + 1,
+    )
+    with open(out_path, "w", encoding="utf-8") as f:
+        for d in [provenance_line] + lines:
+            f.write(json.dumps(d) + "\n")
+
+    src8 = src_session_id[:8]
+    project_basename = Path(src_project_path).name if src_project_path else "?"
+    # meta.json gets ONLY the standard three keys — any extra key is silently
+    # dropped by the harness on first resume, so origin lives in `description`.
+    meta = {
+        "agentType": "general-purpose",
+        "description": f"converted from session {src8} ({project_basename})",
+        "toolUseId": _new_tool_use_id(),
+    }
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(meta, f)
+
+    handoff = _suggested_handoff(src8, project_basename, prior, src_converted_from)
+
+    return ConversionResult(
+        direction="session_to_subagent",
+        created_id=new_agent,
+        turns=len(lines),
+        trimmed_trailing=trimmed,
+        tail_state=_tail_state(lines),
+        models=_model_stats(lines),
+        environment=_environment(lines),
+        lineage=lineage,
+        nested_agents=nested_agents,
+        parent_session=dest_parent_session_id,
+        suggested_handoff=handoff,
+        written_path=out_path,
+        meta_path=meta_path,
+    )
+
+
+def _suggested_handoff(
+    src8: str,
+    project_basename: str,
+    prior_lineage: list[dict[str, str]],
+    src_converted_from: Optional[dict[str, Any]] = None,
+) -> str:
+    """The first-message handoff template, with the lineage-aware first sentence.
+
+    When the SOURCE was itself a subagent-born transcript converted earlier
+    (its own `_converted_from.kind == "subagent"`), the conversation was
+    originally a subagent run inside some parent session, so we phrase its origin
+    that way and name that parent's first 8 chars (recovered from the lineage's
+    last "session" hop — the session that subagent ran under).
+    """
+    born_as_subagent = (
+        src_converted_from is not None and src_converted_from.get("kind") == "subagent"
+    )
+    if born_as_subagent:
+        # The session the original subagent ran inside is the most-recent "session"
+        # hop in the inherited lineage.
+        parent8 = "?"
+        for hop in reversed(prior_lineage):
+            if hop.get("as") == "session":
+                parent8 = str(hop.get("id", ""))[:8]
+                break
+        first = (
+            f"This conversation was a subagent run inside Claude Code session "
+            f"`{parent8}`."
+        )
+    else:
+        first = (
+            f"This conversation was an interactive Claude Code session "
+            f"(`{src8}`, project `{project_basename}`) between Claude and the user."
+        )
+    return (
+        "[CONVERTED SESSION]\n"
+        f"{first} It has been copied and is now continuing as a subagent — the "
+        "original session is untouched. Messages from here on come from the agent "
+        "that resumed you, not from the user above."
+    )
+
+
+# =============================================================================
+# subagent_to_session
+# =============================================================================
+
+
+def convert_subagent_to_session(
+    *,
+    src_agent_id: str,
+    src_path: Path,
+    src_project_path: str,
+    dest_project_dir: Path,
+    dest_title: str,
+) -> ConversionResult:
+    """Copy a subagent transcript out to a new top-level session.
+
+    Mints a fresh session uuid; the written file's name MUST equal the internal
+    sessionId. Refuses to overwrite an existing session file.
+    """
+    raw = _read_raw_lines(src_path)
+    lines = _keep_convo_lines(raw)
+    prior = _prior_lineage(raw)
+
+    new_session = str(uuid.uuid4())
+
+    for d in lines:
+        for k in _STRIP_SUBAGENT_TO_SESSION:
+            d.pop(k, None)
+        d["isSidechain"] = False
+        d["sessionId"] = new_session
+
+    _relinearize(lines)
+    trimmed = _trim_trailing_noise(lines)
+
+    lineage = list(prior) + [
+        {"as": "subagent", "id": src_agent_id},
+        {"as": "session", "id": new_session},
+    ]
+    converted_from = {
+        "kind": "subagent",
+        "id": src_agent_id,
+        "project": src_project_path,
+    }
+    for d in lines:
+        d["_converted_from"] = converted_from
+        d["_lineage"] = lineage
+
+    header = [
+        {"type": "mode", "mode": "normal", "sessionId": new_session},
+        {"type": "permission-mode", "permissionMode": "default", "sessionId": new_session},
+        {"type": "custom-title", "customTitle": dest_title, "sessionId": new_session},
+    ]
+
+    # The provenance line sits right AFTER the custom-title header line: the
+    # mode/permission-mode/custom-title header must lead for the harness to
+    # resolve the file as a session, and provenance is well within read_provenance's
+    # head-scan window. lines_at_creation counts the whole file (header + provenance
+    # + body). agentId is null for session conversions.
+    provenance_line = _provenance_line(
+        src_kind="subagent",
+        src_id=src_agent_id,
+        src_project=src_project_path,
+        session_id=new_session,
+        agent_id=None,
+        lines_at_creation=len(header) + 1 + len(lines),
+    )
+    all_lines = header + [provenance_line] + lines
+
+    out_path = dest_project_dir / f"{new_session}.jsonl"
+    if out_path.exists():
+        raise FileExistsError(
+            f"Refusing to overwrite existing session file: {out_path}"
+        )
+    dest_project_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        for d in all_lines:
+            f.write(json.dumps(d) + "\n")
+
+    return ConversionResult(
+        direction="subagent_to_session",
+        created_id=new_session,
+        turns=len(lines),
+        trimmed_trailing=trimmed,
+        tail_state=_tail_state(lines),
+        models=_model_stats(lines),
+        environment=_environment(lines),
+        lineage=lineage,
+        title=dest_title,
+        project=src_project_path,
+        written_path=out_path,
+    )
+
+
+# =============================================================================
+# Deletion — only artifacts carrying conversion provenance
+# =============================================================================
+
+
+def is_conversion(transcript_path: Path) -> bool:
+    """True when a transcript carries a shape-valid x-converter-provenance line.
+
+    The single trust signal for both directions: meta.json is no longer a trust
+    surface (it's rewritten on resume), so a conversion is identified ONLY by the
+    provenance line at the top of its jsonl. Works for agent and session
+    transcripts alike — read_provenance scans the head and validates the sentinel.
+    """
+    return read_provenance(transcript_path) is not None
+
+
+def growth_exceeded(transcript_path: Path) -> bool:
+    """True when a tagged transcript has grown past its lines_at_creation.
+
+    A resumed-or-built-upon conversion has more lines than it was written with;
+    someone may now depend on it. Callers refuse to delete such files. Returns
+    False (no growth) when there is no valid provenance line — that case is a
+    separate refusal (`not a conversion artifact`), handled by the caller.
+    """
+    sentinel = read_provenance(transcript_path)
+    if sentinel is None:
+        return False
+    created = sentinel.get("lines_at_creation")
+    if not isinstance(created, int):
+        return False
+    return current_line_count(transcript_path) > created
+
+
+def delete_agent_conversion(transcript_path: Path) -> None:
+    """Remove an agent conversion artifact: its transcript and meta sidecar.
+
+    Only subagent conversions are ever deleted by the tool — converted SESSIONS
+    are for humans to manage and are refused unconditionally, so there is no
+    session-deletion counterpart.
+    """
+    meta_path = transcript_path.with_suffix(".meta.json")
+    transcript_path.unlink(missing_ok=True)
+    meta_path.unlink(missing_ok=True)
+
+
+def existing_custom_titles(project_dirs: list[Path]) -> set[str]:
+    """Every custom-title value across all *.jsonl in the given project dirs.
+
+    `claude --resume "<title>"` resolves by scanning custom-title lines, so a
+    duplicate title breaks resolution. We collect existing titles to refuse a
+    colliding dest_title before writing.
+    """
+    titles: set[str] = set()
+    for d in project_dirs:
+        if not d.is_dir():
+            continue
+        for jsonl in d.glob("*.jsonl"):
+            try:
+                with open(jsonl, "r", encoding="utf-8", errors="replace") as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line or '"custom-title"' not in line:
+                            continue
+                        try:
+                            data = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        if data.get("type") == "custom-title":
+                            t = data.get("customTitle")
+                            if isinstance(t, str):
+                                titles.add(t)
+            except OSError:
+                continue
+    return titles

--- a/project-mining/src/cc_explorer/mcp_server.py
+++ b/project-mining/src/cc_explorer/mcp_server.py
@@ -1,21 +1,30 @@
 """MCP server wrapping the cc_explorer library.
 
 Exposes Claude Code chat log exploration as MCP tools via FastMCP.
-All tools are read-only and return typed Pydantic response models.
-FastMCP auto-generates output schemas from return type annotations.
+Most tools are read-only and return typed Pydantic response models; the two
+conversion tools (convert_session, delete_conversions) write/delete transcript
+copies. FastMCP auto-generates output schemas from return type annotations.
 """
 
 import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal, Optional
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from .activity import build_activity_timeline
+from .conversion import (
+    convert_session_to_subagent,
+    convert_subagent_to_session,
+    delete_agent_conversion,
+    existing_custom_titles,
+    growth_exceeded,
+    is_conversion,
+)
 from .formatting import matches_id
 from .models import parse_hide
 from .parser import load_conversations
@@ -27,10 +36,14 @@ from .responses import (
     AgentToolAudit,
     AgentToolCall,
     BrowseSessionResponse,
+    ConvertSessionResponse,
+    DeleteConversionsResponse,
+    DeletedConversion,
     GrepSessionResponse,
     GrepSessionsResponse,
     ProjectListResponse,
     ReadTurnResponse,
+    RefusedDeletion,
     SearchProjectsResponse,
     SessionAgentsResponse,
     SessionListResponse,
@@ -52,9 +65,11 @@ from .search import (
     triage_multi,
 )
 from .subagents import (
+    collect_agent_files,
     discover_subagents,
     extract_agent_tool_audit,
     resolve_output_files,
+    resolve_subagents_dir,
     scan_output_file_stats,
 )
 
@@ -95,6 +110,21 @@ the main transcript, so an agent's own tool calls / thinking are searchable too
 mcp = FastMCP("cc-explorer", instructions=_INSTRUCTIONS)
 
 _TOOL_ANNOTATIONS = {"readOnlyHint": True, "openWorldHint": False}
+
+# convert_session writes new transcript copies (never modifying the source) — not
+# read-only, but not destructive either: it only adds files.
+_CONVERT_ANNOTATIONS = {
+    "readOnlyHint": False,
+    "destructiveHint": False,
+    "openWorldHint": False,
+}
+
+# delete_conversions removes conversion artifacts from disk — destructive.
+_DELETE_ANNOTATIONS = {
+    "readOnlyHint": False,
+    "destructiveHint": True,
+    "openWorldHint": False,
+}
 
 
 # Shared param: which projects to look in. Omit ⇒ ALL projects (cross-project) for
@@ -1091,6 +1121,295 @@ def get_activity_timeline(
         tz=tz,
     )
     return ActivityTimelineResponse.model_validate(result)
+
+
+# =============================================================================
+# Conversion tools — copy a session into a subagent, or a subagent into a session
+# =============================================================================
+
+
+def _resolve_session_for_convert(
+    src_id: str, src_project: str | None
+) -> SessionInfo:
+    """Resolve a session id/prefix to one SessionInfo for conversion, or raise.
+
+    Scopes to `src_project` when given; otherwise searches all projects (locating
+    the holding project cheaply via load_conversations). Ambiguous prefixes raise
+    with the candidate projects listed.
+    """
+    projects = [src_project] if src_project else None
+    narrowed = _projects_for_sessions([src_id], projects)
+    if not narrowed:
+        raise ToolError(f"No session matching: {src_id}")
+    sessions, _ = _load_all_sessions(narrowed)
+    return _resolve_unique_session(sessions, src_id)
+
+
+def _resolve_agent_for_convert(src_id: str, src_project: str | None):
+    """Resolve an agent id/prefix to (AgentFile, holding SessionInfo), or raise.
+
+    Walks every session's subagents dir across the selected projects. A prefix
+    matching agent files in more than one distinct full id raises with the
+    holding sessions listed, mirroring session-prefix ambiguity handling.
+    """
+    proj_sel = [src_project] if src_project else None
+    sessions, _ = _load_all_sessions(proj_sel)
+
+    matches: list[tuple] = []  # (AgentFile, SessionInfo)
+    for s in sessions:
+        for af in collect_agent_files(resolve_subagents_dir(s.path)):
+            if af.agent_id and PrefixId(af.agent_id) == src_id:
+                matches.append((af, s))
+
+    if not matches:
+        raise ToolError(f"No subagent matching: {src_id}")
+    distinct = {af.agent_id for af, _ in matches}
+    if len(distinct) > 1:
+        where = ", ".join(sorted({s.project_path or "?" for _, s in matches}))
+        raise ToolError(
+            f"Agent prefix {src_id!r} is ambiguous — it matches {len(distinct)} "
+            f"distinct agents (in: {where}). Pass a longer id or scope with src_project."
+        )
+    return matches[0]
+
+
+def _project_dirs_for(project_path: str) -> list[Path]:
+    """Every encoded ~/.claude/projects dir that pools into a project.
+
+    Title-collision detection must span the whole project (all worktrees), so we
+    reuse load_conversations' worktree pooling and collect the parent dirs of the
+    discovered transcript files.
+    """
+    refs = load_conversations(project_path)
+    dirs: set[Path] = set()
+    for ref in refs.values():
+        dirs.add(ref.path.parent)
+    return sorted(dirs)
+
+
+@mcp.tool(annotations=_CONVERT_ANNOTATIONS)
+def convert_session(
+    direction: Annotated[
+        Literal["session_to_subagent", "subagent_to_session"],
+        Field(description="Which way to convert: 'session_to_subagent' copies a session into a resumable subagent; 'subagent_to_session' copies a subagent out to a top-level session."),
+    ],
+    src_id: Annotated[
+        str,
+        Field(description="Source id or prefix — a session id (session_to_subagent) or an agent id (subagent_to_session). Must resolve uniquely; an ambiguous prefix errors with the candidates listed."),
+    ],
+    src_project: Annotated[
+        str | None,
+        Field(description="Optional single project (path or bare name) to scope source resolution. Default: search all projects."),
+    ] = None,
+    dest_parent_session: Annotated[
+        str | None,
+        Field(description="session_to_subagent only: the session to parent the new subagent under. Default: the calling session. Errors if omitted and the calling session is unknown."),
+    ] = None,
+    dest_title: Annotated[
+        str | None,
+        Field(description="subagent_to_session only: custom title for the new session. Default: 'converted-<first 8 of src_id>'. Must be unique among custom titles in the dest project; a collision errors."),
+    ] = None,
+    dest_project: Annotated[
+        str | None,
+        Field(description="subagent_to_session only: project (path or bare name) to write the new session into. Default: the source's own project."),
+    ] = None,
+) -> ConvertSessionResponse:
+    """Convert a session into a subagent, or a subagent into a session. Always a copy — the source transcript is never modified, moved, or deleted.
+
+    direction='session_to_subagent': copy a session (any project) into a new subagent parented under dest_parent_session (default: the calling session). The conversation continues as a subagent: resume it like any completed background agent — SendMessage with the returned created_id — and ask it what you need; its whole history is in its context window. Use this when grep answers aren't enough: questions of reasoning, synthesis, or meaning; summaries at any altitude; judgment calls briefed with new evidence; or using a past session as a domain expert whose context you don't want to rebuild.
+
+    direction='subagent_to_session': copy a subagent out to a top-level session a human can open — the response carries the exact `claude -r` command. Use when the user wants to read or continue an agent's run interactively.
+
+    The response includes what you need to compose the first message: suggested_handoff (a converted conversation has no way to know its interlocutor changed — message senders are not labeled on the wire), the original environment (cwd and whether it still exists, git branch, Claude Code version, age), model history, turn count, and tail state. Conversion artifacts carry lineage, are excluded from search by default, and are labeled in agent listings; remove them with delete_conversions."""
+    if direction == "session_to_subagent":
+        src = _resolve_session_for_convert(src_id, src_project)
+
+        parent_id = dest_parent_session or _current_session_id()
+        if not parent_id:
+            raise ToolError(
+                "dest_parent_session is required: the calling session is unknown "
+                "(CLAUDE_CODE_SESSION_ID is not set), so there is no default parent. "
+                "Pass the session id to parent the new subagent under."
+            )
+
+        # The parent session's on-disk directory is <projectDir>/<parentSessionId>.
+        # Resolve it from the parent session itself so worktree-pooled parents land
+        # in the right encoded dir (not assumed to be the source's project).
+        parent = _resolve_session_for_convert(parent_id, None)
+        parent_session_dir = parent.path.with_suffix("")
+
+        # Subagents the SOURCE session ran are NOT copied — their results already
+        # appear inline. Report the count so the caller knows context was folded in.
+        nested = len(discover_subagents(src.path))
+
+        result = convert_session_to_subagent(
+            src_session_id=src.session_id.full,
+            src_path=src.path,
+            src_project_path=src.project_path or "",
+            dest_parent_session_id=parent.session_id.full,
+            dest_parent_session_dir=parent_session_dir,
+            nested_agents=nested,
+        )
+        return ConvertSessionResponse.from_result(result)
+
+    # subagent_to_session
+    af, holding = _resolve_agent_for_convert(src_id, src_project)
+    agent_full = af.agent_id
+
+    dest_proj_path = (
+        resolve_project(dest_project) if dest_project else (holding.project_path or "")
+    )
+    if not dest_proj_path:
+        raise ToolError(
+            "Cannot determine destination project — the source has no project path "
+            "and dest_project was not given."
+        )
+
+    title = dest_title or f"converted-{agent_full[:8]}"
+
+    # `claude --resume "<title>"` resolves by scanning custom-title lines; a
+    # duplicate breaks resolution, so refuse a colliding title up front.
+    taken = existing_custom_titles(_project_dirs_for(dest_proj_path))
+    if title in taken:
+        raise ToolError(
+            f"Title {title!r} already exists in project {Path(dest_proj_path).name!r} — "
+            f"`claude --resume` resolves by title, so it must be unique. Pass a distinct dest_title."
+        )
+
+    # Write into the same encoded dir the source's session lives in (the project's
+    # main transcript dir), so the new session is discoverable under that project.
+    dest_proj_dir = holding.path.parent if not dest_project else _dest_project_dir(dest_proj_path)
+
+    try:
+        result = convert_subagent_to_session(
+            src_agent_id=agent_full,
+            src_path=af.path,
+            src_project_path=dest_proj_path,
+            dest_project_dir=dest_proj_dir,
+            dest_title=title,
+        )
+    except FileExistsError as e:
+        raise ToolError(str(e))
+    return ConvertSessionResponse.from_result(result)
+
+
+def _dest_project_dir(project_path: str) -> Path:
+    """The main-worktree encoded dir for a project, for writing a new session into.
+
+    Reuses load_conversations' pooling to find where the project's main-worktree
+    transcripts live (the first transcript with worktree=None). Falls back to the
+    canonical encoded dir derived from the path when the project has no sessions
+    yet.
+    """
+    refs = load_conversations(project_path)
+    for ref in refs.values():
+        if ref.worktree is None:
+            return ref.path.parent
+    # No main-worktree session on disk yet — derive the encoded dir from the path.
+    from ._claude_paths import _canonicalize_path, _get_project_dir
+
+    return _get_project_dir(_canonicalize_path(project_path))
+
+
+# Refusal reasons (kept as constants so the sweep and explicit-id paths share
+# identical wording, and tests can assert on stable substrings).
+_REFUSE_NOT_CONVERSION = (
+    "not a conversion artifact (no x-converter-provenance line) — refusing to "
+    "delete a real session or subagent"
+)
+_REFUSE_GROWTH = (
+    "conversion has been resumed or built upon since creation; someone may depend "
+    "on it — confirm with the user before removing. The user can remove the files "
+    "manually if confirmed."
+)
+_REFUSE_SESSION = (
+    "converted sessions are for humans to manage; delete_conversions only removes "
+    "subagent conversions. Remove the file manually."
+)
+
+
+@mcp.tool(annotations=_DELETE_ANNOTATIONS)
+def delete_conversions(
+    ids: Annotated[
+        Optional[list[str]],
+        Field(description="Conversion artifact ids (agent ids, prefixes accepted) to delete. Omit to delete ALL conversion-tagged SUBAGENTS under the calling session. Converted SESSIONS are never deletable by this tool (even by explicit id) — remove those files manually."),
+    ] = None,
+) -> DeleteConversionsResponse:
+    """Delete SUBAGENT conversion artifacts created by convert_session — and ONLY those.
+
+    Each subagent id is verified to carry a valid x-converter-provenance line (the sole trust surface — meta.json is rewritten on resume and isn't trusted) before anything is removed. Two guards protect a tagged artifact from deletion: if its line count has grown past `lines_at_creation`, it was resumed or built upon and is refused (someone may now depend on it); ids that resolve to a real but NON-conversion artifact (or don't resolve at all) are refused with a per-id reason. This tool can never delete a genuine session or a normally-dispatched subagent.
+
+    Converted SESSIONS are refused unconditionally — even when tagged and passed by explicit id — because a session is for a human to open and manage; remove its file manually if you mean to. There is no force flag.
+
+    Omit `ids` to sweep every conversion-tagged subagent under the calling session that passes the growth guard (a cleanup-after-yourself default); grown ones are reported in `refused`, not silently skipped."""
+    deleted: list[DeletedConversion] = []
+    refused: list[RefusedDeletion] = []
+
+    if ids is None:
+        # Sweep mode: every conversion subagent under the calling session only.
+        current = _current_session_id()
+        if not current:
+            raise ToolError(
+                "Cannot sweep: the calling session is unknown (CLAUDE_CODE_SESSION_ID "
+                "is not set). Pass explicit ids instead."
+            )
+        try:
+            holding = _resolve_session_for_convert(current, None)
+        except ToolError:
+            return DeleteConversionsResponse(deleted=[], refused=[])
+        for af in collect_agent_files(resolve_subagents_dir(holding.path)):
+            if not af.is_conversion:
+                continue
+            if growth_exceeded(af.path):
+                refused.append(RefusedDeletion(id=af.agent_id, reason=_REFUSE_GROWTH))
+                continue
+            delete_agent_conversion(af.path)
+            deleted.append(
+                DeletedConversion(id=af.agent_id, kind="subagent", path=str(af.path))
+            )
+        return DeleteConversionsResponse(deleted=deleted, refused=refused)
+
+    for raw_id in ids:
+        target = _locate_artifact(raw_id)
+        if target is None:
+            refused.append(
+                RefusedDeletion(id=raw_id, reason="no session or subagent matches this id")
+            )
+            continue
+        kind, full_id, path = target
+        if kind == "session":
+            # Sessions are never deletable here — even tagged ones.
+            refused.append(RefusedDeletion(id=raw_id, reason=_REFUSE_SESSION))
+            continue
+        # subagent
+        if not is_conversion(path):
+            refused.append(RefusedDeletion(id=raw_id, reason=_REFUSE_NOT_CONVERSION))
+            continue
+        if growth_exceeded(path):
+            refused.append(RefusedDeletion(id=raw_id, reason=_REFUSE_GROWTH))
+            continue
+        delete_agent_conversion(path)
+        deleted.append(DeletedConversion(id=full_id, kind="subagent", path=str(path)))
+
+    return DeleteConversionsResponse(deleted=deleted, refused=refused)
+
+
+def _locate_artifact(raw_id: str):
+    """Find a session or subagent by id/prefix across all projects.
+
+    Returns (kind, full_id, path) where kind is 'session' or 'subagent', or None
+    when nothing matches. Sessions are checked first (an id is a session id or an
+    agent id, never both). The path is the transcript file to act on.
+    """
+    sessions, _ = _load_all_sessions(None)
+    for s in sessions:
+        if PrefixId(s.session_id) == raw_id:
+            return ("session", s.session_id.full, s.path)
+    for s in sessions:
+        for af in collect_agent_files(resolve_subagents_dir(s.path)):
+            if af.agent_id and PrefixId(af.agent_id) == raw_id:
+                return ("subagent", af.agent_id, af.path)
+    return None
 
 
 def main():

--- a/project-mining/src/cc_explorer/mcp_server.py
+++ b/project-mining/src/cc_explorer/mcp_server.py
@@ -23,7 +23,7 @@ from .conversion import (
     delete_agent_conversion,
     existing_custom_titles,
     growth_exceeded,
-    is_conversion,
+    is_conversion_artifact,
 )
 from .formatting import matches_id
 from .models import parse_hide
@@ -1041,6 +1041,10 @@ def audit_session_tools(
     total_calls = 0
     total_errors = 0
     for sa in agents:
+        # Conversion artifacts are copies of real transcripts — skip them so
+        # their tool calls (which are the source's) are not counted twice.
+        if sa.is_conversion_artifact:
+            continue
         if not sa.agent_id or sa.agent_id not in entries_map:
             continue
 
@@ -1220,7 +1224,7 @@ def convert_session(
 
     direction='subagent_to_session': copy a subagent out to a top-level session a human can open — the response carries the exact `claude -r` command. Use when the user wants to read or continue an agent's run interactively.
 
-    The response includes what you need to compose the first message: suggested_handoff (a converted conversation has no way to know its interlocutor changed — message senders are not labeled on the wire), the original environment (cwd and whether it still exists, git branch, Claude Code version, age), model history, turn count, and tail state. Conversion artifacts carry lineage, are excluded from search by default, and are labeled in agent listings; remove them with delete_conversions."""
+    The response includes what you need to compose the first message: suggested_handoff (a converted conversation has no way to know its interlocutor changed — message senders are not labeled on the wire), the original environment (cwd and whether it still exists, git branch, Claude Code version, age), model history, turn count, and tail state. Conversion artifacts carry lineage, are excluded from search, and are labeled in agent listings; remove them with delete_conversions."""
     if direction == "session_to_subagent":
         src = _resolve_session_for_convert(src_id, src_project)
 
@@ -1240,7 +1244,11 @@ def convert_session(
 
         # Subagents the SOURCE session ran are NOT copied — their results already
         # appear inline. Report the count so the caller knows context was folded in.
-        nested = len(discover_subagents(src.path))
+        # Conversion artifacts are excluded — they are copies, not dispatched runs.
+        nested = sum(
+            1 for sa in discover_subagents(src.path)
+            if not sa.is_conversion_artifact
+        )
 
         result = convert_session_to_subagent(
             src_session_id=src.session_id.full,
@@ -1280,16 +1288,25 @@ def convert_session(
     # main transcript dir), so the new session is discoverable under that project.
     dest_proj_dir = holding.path.parent if not dest_project else _dest_project_dir(dest_proj_path)
 
+    # src_project_path is the HOLDING project (where the source subagent lives),
+    # not the destination. This is what gets stamped into provenance/from.project
+    # and _converted_from.project. The response.project continues to carry the
+    # destination project (set on ConversionResult.project via the caller below).
+    src_proj_path = holding.project_path or ""
+
     try:
         result = convert_subagent_to_session(
             src_agent_id=agent_full,
             src_path=af.path,
-            src_project_path=dest_proj_path,
+            src_project_path=src_proj_path,
             dest_project_dir=dest_proj_dir,
             dest_title=title,
         )
     except FileExistsError as e:
         raise ToolError(str(e))
+    # Override result.project to the destination (conversion.py sets it to
+    # src_project_path; callers expect response.project == destination project).
+    result.project = dest_proj_path
     return ConvertSessionResponse.from_result(result)
 
 
@@ -1355,10 +1372,14 @@ def delete_conversions(
             )
         try:
             holding = _resolve_session_for_convert(current, None)
-        except ToolError:
-            return DeleteConversionsResponse(deleted=[], refused=[])
+        except ToolError as e:
+            raise ToolError(
+                f"delete_conversions sweep failed: could not resolve the calling "
+                f"session ({current!r}): {e}. "
+                f"Pass explicit ids instead of relying on the sweep."
+            ) from e
         for af in collect_agent_files(resolve_subagents_dir(holding.path)):
-            if not af.is_conversion:
+            if not af.is_conversion_artifact:
                 continue
             if growth_exceeded(af.path):
                 refused.append(RefusedDeletion(id=af.agent_id, reason=_REFUSE_GROWTH))
@@ -1369,20 +1390,22 @@ def delete_conversions(
             )
         return DeleteConversionsResponse(deleted=deleted, refused=refused)
 
-    for raw_id in ids:
-        target = _locate_artifact(raw_id)
-        if target is None:
+    # Load corpus once for all ids.
+    all_sessions, _ = _load_all_sessions(None)
+    resolved = _resolve_artifacts_corpus(ids, all_sessions)
+
+    for raw_id, kind, full_id, path in resolved:
+        if not kind:
             refused.append(
                 RefusedDeletion(id=raw_id, reason="no session or subagent matches this id")
             )
             continue
-        kind, full_id, path = target
         if kind == "session":
             # Sessions are never deletable here — even tagged ones.
             refused.append(RefusedDeletion(id=raw_id, reason=_REFUSE_SESSION))
             continue
         # subagent
-        if not is_conversion(path):
+        if not is_conversion_artifact(path):
             refused.append(RefusedDeletion(id=raw_id, reason=_REFUSE_NOT_CONVERSION))
             continue
         if growth_exceeded(path):
@@ -1394,22 +1417,66 @@ def delete_conversions(
     return DeleteConversionsResponse(deleted=deleted, refused=refused)
 
 
-def _locate_artifact(raw_id: str):
-    """Find a session or subagent by id/prefix across all projects.
+_MIN_ID_LEN = 6  # IDs shorter than this are refused to avoid accidental prefix sweeps.
 
-    Returns (kind, full_id, path) where kind is 'session' or 'subagent', or None
-    when nothing matches. Sessions are checked first (an id is a session id or an
-    agent id, never both). The path is the transcript file to act on.
+
+def _resolve_artifacts_corpus(
+    raw_ids: list[str],
+    sessions: list,
+) -> list[tuple[str, str, str, Path]]:
+    """Resolve a list of ids to (raw_id, kind, full_id, path) tuples, raising on any problem.
+
+    Loads the corpus ONCE (caller passes `sessions`). For each id:
+      - Rejects ids shorter than _MIN_ID_LEN with a clear error.
+      - Finds ALL matching sessions and agent files for the id.
+      - Raises ToolError on ambiguity (listing candidates + their projects).
+      - Returns a 4-tuple on unique match, or None-placeholder for no match.
+
+    Returns list of resolved tuples; no-match entries are represented as
+    (raw_id, "", "", None) so the caller can format its own refused reason.
     """
-    sessions, _ = _load_all_sessions(None)
-    for s in sessions:
-        if PrefixId(s.session_id) == raw_id:
-            return ("session", s.session_id.full, s.path)
+    # Build agent index once: (agent_id, session_path, project_path, af_path)
+    agent_index: list[tuple[str, str, Path]] = []
     for s in sessions:
         for af in collect_agent_files(resolve_subagents_dir(s.path)):
-            if af.agent_id and PrefixId(af.agent_id) == raw_id:
-                return ("subagent", af.agent_id, af.path)
-    return None
+            if af.agent_id:
+                agent_index.append((af.agent_id, s.project_path or "?", af.path))
+
+    resolved: list[tuple[str, str, str, Path | None]] = []
+    for raw_id in raw_ids:
+        if len(raw_id) < _MIN_ID_LEN:
+            raise ToolError(
+                f"Id {raw_id!r} is too short ({len(raw_id)} chars) — pass at least "
+                f"{_MIN_ID_LEN} chars to avoid accidental prefix matches. "
+                f"Use list_project_sessions or list_session_agents to find full ids."
+            )
+        # Session matches
+        session_matches = [s for s in sessions if PrefixId(s.session_id) == raw_id]
+        distinct_sess = {s.session_id.full for s in session_matches}
+        # Agent matches
+        agent_matches = [(fid, proj, p) for fid, proj, p in agent_index if PrefixId(fid) == raw_id]
+        distinct_agents = {fid for fid, _, _ in agent_matches}
+
+        total_kinds = len(distinct_sess) + len(distinct_agents)
+        if total_kinds > 1:
+            candidates: list[str] = []
+            for s in session_matches:
+                candidates.append(f"session {s.session_id.full[:12]} in {s.project_path or '?'}")
+            for fid, proj, _ in agent_matches:
+                candidates.append(f"agent {fid[:12]} in {proj}")
+            raise ToolError(
+                f"Id prefix {raw_id!r} is ambiguous — it matches {total_kinds} distinct "
+                f"artifacts: {'; '.join(candidates)}. Pass a longer id to disambiguate."
+            )
+        if len(distinct_sess) == 1:
+            s = session_matches[0]
+            resolved.append((raw_id, "session", s.session_id.full, s.path))
+        elif len(distinct_agents) == 1:
+            fid, _, p = agent_matches[0]
+            resolved.append((raw_id, "subagent", fid, p))
+        else:
+            resolved.append((raw_id, "", "", None))
+    return resolved
 
 
 def main():

--- a/project-mining/src/cc_explorer/responses.py
+++ b/project-mining/src/cc_explorer/responses.py
@@ -67,6 +67,10 @@ class SessionSummary(SparseModel):
         default=None,
         description="True for the calling conversation itself — the session you are reading this from. Absent for every other session. Use it to skip yourself.",
     )
+    is_conversion_artifact: bool | None = Field(
+        default=None,
+        description="True when this session is a conversion artifact — copied here via convert_session, not an original conversation. Its content duplicates the source transcript. Remove with delete_conversions (converted sessions are managed manually). Absent for normal sessions.",
+    )
 
     @classmethod
     def from_session_info(cls, s: SessionInfo, is_current: bool = False) -> SessionSummary:
@@ -86,6 +90,7 @@ class SessionSummary(SparseModel):
             output_tokens=s.stats.output_tokens,
             tools=s.stats.tool_use_count,
             is_current=is_current or None,
+            is_conversion_artifact=s.is_conversion_artifact or None,
         )
 
 
@@ -537,9 +542,9 @@ class AgentSummary(SparseModel):
         default=None,
         description="The workflow run this agent belongs to; null if it wasn't spawned by a workflow. Agents sharing a value ran in the same workflow.",
     )
-    is_conversion: bool | None = Field(
+    is_conversion_artifact: bool | None = Field(
         default=None,
-        description="True when this agent is a CONVERSION ARTIFACT — a session or subagent copied here via convert_session, not a real dispatched run. Its transcript duplicates a real one and is excluded from search by default. Remove it with delete_conversions. Absent for normal agents.",
+        description="True when this agent is a CONVERSION ARTIFACT — a session or subagent copied here via convert_session, not a real dispatched run. Its transcript duplicates a real one and is excluded from search. Remove it with delete_conversions. Absent for normal agents.",
     )
     date: datetime | None = Field(default=None, description="Timestamp when agent was spawned.")
     type: str = Field(description="Subagent type (e.g. 'general-purpose', 'Explore').")
@@ -557,7 +562,7 @@ class AgentSummary(SparseModel):
             tool_use_id=sa.tool_use_id,
             source=sa.source,
             workflow_run_id=sa.workflow_run_id,
-            is_conversion=sa.is_conversion or None,
+            is_conversion_artifact=sa.is_conversion_artifact or None,
             date=sa.timestamp,
             type=sa.subagent_type or "",
             status=sa.status,
@@ -970,6 +975,10 @@ class ConvertSessionResponse(SparseModel):
     project: str | None = Field(default=None, description="subagent_to_session: the project the new session was written to.")
     turns: int = Field(description="Conversation turns copied (user+assistant), after trailing trim.")
     trimmed_trailing: int = Field(description="Trailing noise turns dropped (empty/interrupt/command scaffolding).")
+    dropped_branches: int | None = Field(
+        default=None,
+        description="Lines dropped because they were on abandoned edit-branches or embedded sidechain turns not on the active thread. 0 when nothing was dropped; absent when no walk was possible (fallback to file order).",
+    )
     tail_state: str = Field(description="'clean' (ends on an assistant turn) or 'pending_user_input' (ends on a real user turn awaiting a reply).")
     nested_agents: int | None = Field(
         default=None,
@@ -1004,6 +1013,7 @@ class ConvertSessionResponse(SparseModel):
             project=r.project,
             turns=r.turns,
             trimmed_trailing=r.trimmed_trailing,
+            dropped_branches=r.dropped_branches if r.dropped_branches is not None else None,
             tail_state=r.tail_state,
             nested_agents=(r.nested_agents or None) if r.direction == "session_to_subagent" else None,
             models=ConversionModels(**r.models),

--- a/project-mining/src/cc_explorer/responses.py
+++ b/project-mining/src/cc_explorer/responses.py
@@ -537,6 +537,10 @@ class AgentSummary(SparseModel):
         default=None,
         description="The workflow run this agent belongs to; null if it wasn't spawned by a workflow. Agents sharing a value ran in the same workflow.",
     )
+    is_conversion: bool | None = Field(
+        default=None,
+        description="True when this agent is a CONVERSION ARTIFACT — a session or subagent copied here via convert_session, not a real dispatched run. Its transcript duplicates a real one and is excluded from search by default. Remove it with delete_conversions. Absent for normal agents.",
+    )
     date: datetime | None = Field(default=None, description="Timestamp when agent was spawned.")
     type: str = Field(description="Subagent type (e.g. 'general-purpose', 'Explore').")
     status: str = Field(description="Agent status: completed, error, async_launched, unknown.")
@@ -553,6 +557,7 @@ class AgentSummary(SparseModel):
             tool_use_id=sa.tool_use_id,
             source=sa.source,
             workflow_run_id=sa.workflow_run_id,
+            is_conversion=sa.is_conversion or None,
             date=sa.timestamp,
             type=sa.subagent_type or "",
             status=sa.status,
@@ -901,4 +906,144 @@ class ActivityTimelineResponse(SparseModel):
     sessions: list[ActivitySession] = Field(description="Interactive sessions first (turn_min desc), then headless (turn_min desc).")
     timeline: dict[str, dict[str, list[int]]] = Field(
         description="Time-major sparse grid: {'MM-DD HH:MM': {session_id: [human_turns, agent_turns]}}. Active buckets only; ALL sessions incl. headless; subagents folded into the parent as agent turns."
+    )
+
+
+# =============================================================================
+# convert_session
+# =============================================================================
+#
+# Lead with the actionable: `operation`/`direction`/`created_id`/`invocation`
+# come first so the agent sees "what was created and how to use it" before the
+# diagnostic detail (environment, models, lineage) that survives truncation
+# below it.
+
+
+class ConversionModels(SparseModel):
+    """Assistant model history of the converted transcript."""
+
+    first: str | None = Field(default=None, description="First assistant model id in the copy.")
+    last: str | None = Field(default=None, description="Last assistant model id in the copy.")
+    counts: dict[str, int] = Field(
+        default_factory=dict, description="model id -> number of assistant turns."
+    )
+
+
+class ConversionEnvironment(SparseModel):
+    """The converted conversation's original runtime context.
+
+    A converted conversation has no live environment of its own — these are read
+    off the source transcript so the caller can judge whether the cwd/branch it
+    assumed still exist before acting on its answers.
+    """
+
+    original_cwd: str | None = Field(default=None, description="cwd the source ran in.")
+    cwd_exists: bool = Field(description="Whether original_cwd still exists on disk.")
+    original_branch: str | None = Field(default=None, description="gitBranch the source ran on.")
+    branch_exists: bool | None = Field(
+        default=None,
+        description="Whether original_branch is still a valid ref. null when the cwd is gone or isn't a git repo (can't tell).",
+    )
+    cc_version: str | None = Field(default=None, description="Claude Code version the source ran under.")
+    last_timestamp: str | None = Field(default=None, description="Timestamp of the source's last turn.")
+    age_days: int | None = Field(default=None, description="Whole days from the source's last turn to now.")
+
+
+class ConvertSessionResponse(SparseModel):
+    """Result of a session<->subagent conversion (always a copy).
+
+    Leads with what was created and the exact next step (`invocation`). The
+    source transcript is never touched. `suggested_handoff` is the first message
+    to send a converted session, since a copied conversation can't tell its
+    interlocutor changed.
+    """
+
+    operation: str = Field(description="Always 'copy' — the source is never modified, moved, or deleted.")
+    direction: str = Field(description="'session_to_subagent' or 'subagent_to_session'.")
+    created_id: str = Field(description="The new agent id (session_to_subagent) or session uuid (subagent_to_session).")
+    invocation: str = Field(description="The exact next step to use the created artifact.")
+    parent_session: str | None = Field(
+        default=None,
+        description="session_to_subagent: the session the new subagent is parented under.",
+    )
+    title: str | None = Field(default=None, description="subagent_to_session: the new session's custom title.")
+    project: str | None = Field(default=None, description="subagent_to_session: the project the new session was written to.")
+    turns: int = Field(description="Conversation turns copied (user+assistant), after trailing trim.")
+    trimmed_trailing: int = Field(description="Trailing noise turns dropped (empty/interrupt/command scaffolding).")
+    tail_state: str = Field(description="'clean' (ends on an assistant turn) or 'pending_user_input' (ends on a real user turn awaiting a reply).")
+    nested_agents: int | None = Field(
+        default=None,
+        description="session_to_subagent only: subagents the SOURCE session ran. They are NOT copied — their results already appear inline in the conversation. Absent/0 for subagent sources.",
+    )
+    models: ConversionModels = Field(description="Assistant model history of the copy.")
+    environment: ConversionEnvironment = Field(description="The source's original cwd/branch/version/age.")
+    suggested_handoff: str | None = Field(
+        default=None,
+        description="session_to_subagent only: the first message to send the converted subagent, telling it its interlocutor changed (senders are not labeled on the wire).",
+    )
+    lineage: list[dict[str, str]] = Field(
+        description="Accumulated conversion chain: each hop is {as: 'session'|'subagent', id: ...}, oldest first.",
+    )
+
+    @classmethod
+    def from_result(cls, r) -> "ConvertSessionResponse":
+        if r.direction == "session_to_subagent":
+            invocation = f'SendMessage(to: "{r.created_id}")'
+        else:
+            invocation = (
+                f"claude -r {r.created_id}   "
+                f'(or: claude --resume "{r.title}" — resolves by title too)'
+            )
+        return cls(
+            operation="copy",
+            direction=r.direction,
+            created_id=r.created_id,
+            invocation=invocation,
+            parent_session=r.parent_session,
+            title=r.title,
+            project=r.project,
+            turns=r.turns,
+            trimmed_trailing=r.trimmed_trailing,
+            tail_state=r.tail_state,
+            nested_agents=(r.nested_agents or None) if r.direction == "session_to_subagent" else None,
+            models=ConversionModels(**r.models),
+            environment=ConversionEnvironment(**r.environment),
+            suggested_handoff=r.suggested_handoff,
+            lineage=r.lineage,
+        )
+
+
+# =============================================================================
+# delete_conversions
+# =============================================================================
+
+
+class DeletedConversion(SparseModel):
+    """One conversion artifact that was deleted."""
+
+    id: str = Field(description="The agent id or session id deleted.")
+    kind: str = Field(description="'subagent' or 'session'.")
+    path: str = Field(description="Transcript file that was removed.")
+
+
+class RefusedDeletion(SparseModel):
+    """One id that was NOT deleted, with the reason."""
+
+    id: str = Field(description="The id that was refused.")
+    reason: str = Field(description="Why it wasn't deleted: not found, not a conversion artifact (no provenance line), grown since creation (resumed/built upon), or a converted session (humans manage those).")
+
+
+class DeleteConversionsResponse(SparseModel):
+    """Result of delete_conversions: what was removed and what was refused.
+
+    Only SUBAGENT artifacts carrying a valid x-converter-provenance line AND
+    unchanged since creation are deletable. Grown artifacts, converted sessions,
+    and non-conversion files are refused with a per-id reason rather than touched.
+    """
+
+    deleted: list[DeletedConversion] = Field(
+        default_factory=list, description="Conversion artifacts removed."
+    )
+    refused: list[RefusedDeletion] = Field(
+        default_factory=list, description="Ids not removed, each with a reason."
     )

--- a/project-mining/src/cc_explorer/search.py
+++ b/project-mining/src/cc_explorer/search.py
@@ -28,6 +28,7 @@ from .models import (
     substantive_human_text,
 )
 from .formatting import _match_example
+from .conversion import read_provenance
 from .parser import load_conversations, load_transcript
 from .subagents import collect_agent_files, discover_subagents, resolve_subagents_dir
 from .utils import PrefixId, smart_truncate
@@ -302,7 +303,7 @@ def session_sources(session: "SessionInfo") -> list["TranscriptSource"]:
     """
     sources: list[TranscriptSource] = [TranscriptSource(agent_id=None, path=session.path)]
     for af in collect_agent_files(resolve_subagents_dir(session.path)):
-        if af.is_conversion:
+        if af.is_conversion_artifact:
             continue
         sources.append(
             TranscriptSource(
@@ -397,6 +398,11 @@ class SessionInfo:
     # orphans (notably workflow-orchestrated agents). Equals list_session_agents'
     # total_agents, unlike stats.agent_count which is top-down dispatches only.
     agents_present: int = 0
+    # True when this session is a conversion artifact (x-converter-provenance line
+    # present). Populated at load time via a cheap head-scan; used to skip
+    # artifacts from search/triage (same rationale as agent-shaped skip) while
+    # still listing them in session list responses (labeled).
+    is_conversion_artifact: bool = False
 
 
 @dataclass
@@ -585,11 +591,17 @@ def load_sessions(
         # count matches list_session_agents and catches workflow orphans. Reuses
         # the already-parsed entries — only the tiny subagents/ dir is walked.
         # Gated: most tools don't need it and shouldn't pay the per-session walk.
+        # Conversion artifacts are excluded — they are copies, not dispatched runs.
         agents_present = (
-            len(discover_subagents(ref.path, entries=entries))
+            sum(
+                1 for sa in discover_subagents(ref.path, entries=entries)
+                if not sa.is_conversion_artifact
+            )
             if with_agents_present
             else 0
         )
+        # Cheap head-scan: is this session a conversion artifact?
+        is_conv = read_provenance(ref.path) is not None
         sessions.append(
             SessionInfo(
                 session_id=session_id,
@@ -604,6 +616,7 @@ def load_sessions(
                 team_role=team_role,
                 agents_present=agents_present,
                 project_path=project_path,
+                is_conversion_artifact=is_conv,
             )
         )
 
@@ -715,6 +728,8 @@ def triage(
     results: list[TriageResult] = []
 
     for session in sessions:
+        if session.is_conversion_artifact:
+            continue
         count = 0
         first_example = ""
         first_agent_id: Optional[PrefixId] = None
@@ -765,6 +780,8 @@ def triage_multi(
     }
 
     for si, session in enumerate(sessions):
+        if session.is_conversion_artifact:
+            continue
         # Search the whole corpus: main transcript + every subagent body (#22).
         for source in session_sources(session):
             entries = load_transcript(source.path)
@@ -827,6 +844,8 @@ def search_multi(
     out: dict[PrefixId, list[tuple[str, list[MatchHit], int]]] = {}
 
     for session in sessions:
+        if session.is_conversion_artifact:
+            continue
         # Per-pattern accumulator for this session: pi -> list[MatchHit]
         per_pattern: dict[int, list[MatchHit]] = {i: [] for i in range(len(compiled))}
         per_pattern_totals: dict[int, int] = {i: 0 for i in range(len(compiled))}
@@ -892,6 +911,8 @@ def search(
         target_sessions = [s for s in sessions if s.session_id == session_id]
 
     for session in target_sessions:
+        if session.is_conversion_artifact:
+            continue
         session_matches: list[MatchHit] = []
 
         for source in session_sources(session):

--- a/project-mining/src/cc_explorer/search.py
+++ b/project-mining/src/cc_explorer/search.py
@@ -293,9 +293,17 @@ def session_sources(session: "SessionInfo") -> list["TranscriptSource"]:
     NOTE: this walks every session's subagent dir, so a cross-project search
     touches the whole tree — the known cost tracked as the whole-corpus perf
     follow-up. Correctness first.
+
+    Conversion artifacts (agents whose jsonl carries an x-converter-provenance
+    line, i.e. a session/subagent copied via convert_session) are SKIPPED: their
+    text is a duplicate of a real transcript already in the corpus, so searching
+    them would double-count and surface synthetic copies. They remain visible in
+    list_session_agents (labeled), just not searched.
     """
     sources: list[TranscriptSource] = [TranscriptSource(agent_id=None, path=session.path)]
     for af in collect_agent_files(resolve_subagents_dir(session.path)):
+        if af.is_conversion:
+            continue
         sources.append(
             TranscriptSource(
                 agent_id=PrefixId(af.agent_id) if af.agent_id else None,

--- a/project-mining/src/cc_explorer/subagents.py
+++ b/project-mining/src/cc_explorer/subagents.py
@@ -67,11 +67,8 @@ class SubagentInfo:
     source: str = ""
     # Workflow run id for agents under subagents/workflows/<runId>/, else None.
     workflow_run_id: Optional[str] = None
-    # True when this agent is a conversion artifact (its jsonl carries an
-    # x-converter-provenance line — written by convert_session). Conversion
-    # artifacts are excluded from the search corpus by default and labeled in
-    # agent listings; delete_conversions removes them.
-    is_conversion: bool = False
+    # Conversion artifact (made by convert_session), not a real dispatched run.
+    is_conversion_artifact: bool = False
 
     # Completion stats (from toolUseResult on completed agents)
     # Optional here is meaningful — distinguishes "no data" from "zero usage"
@@ -263,11 +260,8 @@ class AgentFile:
     agent_type: str = ""  # meta.json agentType
     description: str = ""  # meta.json description
     tool_use_id: str = ""  # meta.json toolUseId (links back to a parent dispatch)
-    # True when the jsonl carries an x-converter-provenance line — this agent is
-    # a conversion artifact (a session/subagent copied via convert_session), not a
-    # real dispatched run. Keyed on the provenance line, NOT meta.json (which the
-    # harness rewrites on resume). Excluded from the search corpus by default.
-    is_conversion: bool = False
+    # Conversion artifact — keyed on the provenance line; conversion.py owns the why.
+    is_conversion_artifact: bool = False
 
 
 def resolve_subagents_dir(session_path: Path) -> Path:
@@ -334,10 +328,6 @@ def collect_agent_files(subagents_dir: Path) -> list[AgentFile]:
             ):
                 agent_id = name[len("agent-") : -len(".jsonl")]
                 meta = _read_agent_meta(entry)
-                # Conversion status keys on the x-converter-provenance line in the
-                # jsonl (written first), NOT meta.json — the harness rewrites
-                # meta.json on resume and drops unknown keys, so it's not a durable
-                # trust surface. read_provenance reads just the head of the file.
                 found.append(
                     AgentFile(
                         agent_id=agent_id,
@@ -346,7 +336,7 @@ def collect_agent_files(subagents_dir: Path) -> list[AgentFile]:
                         agent_type=meta.get("agentType", ""),
                         description=meta.get("description", ""),
                         tool_use_id=meta.get("toolUseId", ""),
-                        is_conversion=read_provenance(entry) is not None,
+                        is_conversion_artifact=read_provenance(entry) is not None,
                     )
                 )
 
@@ -419,7 +409,7 @@ def discover_subagents(
                 target.agent_id = PrefixId(af.agent_id)
             target.workflow_run_id = af.workflow_run_id
             target.source = "dispatched"
-            target.is_conversion = af.is_conversion
+            target.is_conversion_artifact = af.is_conversion_artifact
             _attach_transcript_file(target, af.path)
             matched.add(id(target))
         else:
@@ -430,7 +420,7 @@ def discover_subagents(
                 description=af.description,
                 workflow_run_id=af.workflow_run_id,
                 source="orphan",
-                is_conversion=af.is_conversion,
+                is_conversion_artifact=af.is_conversion_artifact,
             )
             _attach_transcript_file(info, af.path)
             orphans.append(info)

--- a/project-mining/src/cc_explorer/subagents.py
+++ b/project-mining/src/cc_explorer/subagents.py
@@ -41,6 +41,7 @@ from .models import (
     extract_text,
     substantive_human_text,
 )
+from .conversion import read_provenance
 from .parser import load_transcript
 from .utils import PrefixId
 
@@ -66,6 +67,11 @@ class SubagentInfo:
     source: str = ""
     # Workflow run id for agents under subagents/workflows/<runId>/, else None.
     workflow_run_id: Optional[str] = None
+    # True when this agent is a conversion artifact (its jsonl carries an
+    # x-converter-provenance line — written by convert_session). Conversion
+    # artifacts are excluded from the search corpus by default and labeled in
+    # agent listings; delete_conversions removes them.
+    is_conversion: bool = False
 
     # Completion stats (from toolUseResult on completed agents)
     # Optional here is meaningful — distinguishes "no data" from "zero usage"
@@ -257,6 +263,11 @@ class AgentFile:
     agent_type: str = ""  # meta.json agentType
     description: str = ""  # meta.json description
     tool_use_id: str = ""  # meta.json toolUseId (links back to a parent dispatch)
+    # True when the jsonl carries an x-converter-provenance line — this agent is
+    # a conversion artifact (a session/subagent copied via convert_session), not a
+    # real dispatched run. Keyed on the provenance line, NOT meta.json (which the
+    # harness rewrites on resume). Excluded from the search corpus by default.
+    is_conversion: bool = False
 
 
 def resolve_subagents_dir(session_path: Path) -> Path:
@@ -283,7 +294,7 @@ def _workflow_run_id(path: Path, base_dir: Path) -> Optional[str]:
     return None
 
 
-def _read_agent_meta(transcript_path: Path) -> dict[str, str]:
+def _read_agent_meta(transcript_path: Path) -> dict[str, Any]:
     """Read the `.meta.json` sidecar next to an agent transcript. Empty dict if absent."""
     meta_path = transcript_path.with_suffix(".meta.json")
     try:
@@ -323,6 +334,10 @@ def collect_agent_files(subagents_dir: Path) -> list[AgentFile]:
             ):
                 agent_id = name[len("agent-") : -len(".jsonl")]
                 meta = _read_agent_meta(entry)
+                # Conversion status keys on the x-converter-provenance line in the
+                # jsonl (written first), NOT meta.json — the harness rewrites
+                # meta.json on resume and drops unknown keys, so it's not a durable
+                # trust surface. read_provenance reads just the head of the file.
                 found.append(
                     AgentFile(
                         agent_id=agent_id,
@@ -331,6 +346,7 @@ def collect_agent_files(subagents_dir: Path) -> list[AgentFile]:
                         agent_type=meta.get("agentType", ""),
                         description=meta.get("description", ""),
                         tool_use_id=meta.get("toolUseId", ""),
+                        is_conversion=read_provenance(entry) is not None,
                     )
                 )
 
@@ -403,6 +419,7 @@ def discover_subagents(
                 target.agent_id = PrefixId(af.agent_id)
             target.workflow_run_id = af.workflow_run_id
             target.source = "dispatched"
+            target.is_conversion = af.is_conversion
             _attach_transcript_file(target, af.path)
             matched.add(id(target))
         else:
@@ -413,6 +430,7 @@ def discover_subagents(
                 description=af.description,
                 workflow_run_id=af.workflow_run_id,
                 source="orphan",
+                is_conversion=af.is_conversion,
             )
             _attach_transcript_file(info, af.path)
             orphans.append(info)

--- a/project-mining/tests/test_conversion.py
+++ b/project-mining/tests/test_conversion.py
@@ -1,0 +1,780 @@
+"""Tests for session<->subagent conversion (convert_session / delete_conversions).
+
+All fixtures are SYNTHESIZED — builder helpers emit fake transcript dicts; no
+real conversation content appears here (this is a public repo). The fake
+~/.claude/projects root is a tmp_path-based CLAUDE_CONFIG_DIR, with
+_get_worktree_paths patched to [] so each project pools as itself (no git).
+
+Coverage:
+  - roundtrip fidelity: session -> subagent -> session preserves conversation text
+  - tree source relinearizes to a valid linear chain
+  - trailing-noise trim
+  - prefix ambiguity raises
+  - title collision raises
+  - refuse to overwrite an existing session file
+  - cross-project src resolution
+  - x-converter-provenance line is the sole trust surface: present at the top of
+    agent jsonl (line 1) and session jsonl (after custom-title); meta.json carries
+    only the three standard keys
+  - delete_conversions: refuses subagents with no provenance line, refuses grown
+    subagents (growth guard), refuses sessions unconditionally (even tagged),
+    deletes ungrown tagged subagents; sweep reports growth-skips
+  - lineage accumulates across two conversions
+  - conversion-tagged agents excluded from search corpus but present in
+    list_session_agents (labeled)
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+import cc_explorer._claude_paths as paths
+import cc_explorer.mcp_server as srv
+from cc_explorer.search import SessionInfo, session_sources, triage_multi
+from cc_explorer.subagents import collect_agent_files, resolve_subagents_dir
+from cc_explorer.utils import PrefixId
+
+TS = "2026-03-15T10:30:00.000Z"
+CWD = "/Users/test/projects/demo"
+PROJECT = "/Users/test/projects/demo"
+
+
+# =============================================================================
+# Synthesized transcript builders
+# =============================================================================
+
+
+def _user(uuid: str, text: str, *, parent: str | None = None, **extra) -> dict:
+    # NOTE: cwd is intentionally NOT set here — write_session stamps it per-project
+    # so a session written to a given project pools under that project's dir.
+    line = {
+        "type": "user",
+        "uuid": uuid,
+        "parentUuid": parent,
+        "timestamp": TS,
+        "sessionId": "SID",
+        "version": "2.1.175",
+        "gitBranch": "main",
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+    line.update(extra)
+    return line
+
+
+def _assistant(uuid: str, text: str, *, parent: str | None = None, model="claude-opus-4-8", **extra) -> dict:
+    line = {
+        "type": "assistant",
+        "uuid": uuid,
+        "parentUuid": parent,
+        "timestamp": TS,
+        "sessionId": "SID",
+        "version": "2.1.175",
+        "gitBranch": "main",
+        "message": {
+            "id": "msg_" + uuid,
+            "type": "message",
+            "role": "assistant",
+            "model": model,
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+    line.update(extra)
+    return line
+
+
+def _write_jsonl(path: Path, lines: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(l) for l in lines) + "\n", encoding="utf-8")
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(l) for l in path.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+# The own-type provenance line is the single trust surface (meta.json is not).
+PROVENANCE_TYPE = "x-converter-provenance"
+
+
+def _provenance_lines(lines: list[dict]) -> list[dict]:
+    return [l for l in lines if l.get("type") == PROVENANCE_TYPE]
+
+
+def _convo_only(lines: list[dict]) -> list[dict]:
+    """Body lines, dropping the provenance line and any session header lines."""
+    return [l for l in lines if l.get("type") in ("user", "assistant")]
+
+
+def _fake_provenance_line(agent_id: str, *, lines_at_creation: int, kind: str = "session") -> dict:
+    """A shape-valid x-converter-provenance line for synthesizing tagged artifacts."""
+    return {
+        "type": PROVENANCE_TYPE,
+        "x_converter": {
+            "tool": "convert_session",
+            "v": 1,
+            "from": {"kind": kind, "id": "x", "project": PROJECT},
+            "converted_at": TS,
+            "lines_at_creation": lines_at_creation,
+        },
+        "sessionId": SID_PARENT,
+        "agentId": agent_id,
+    }
+
+
+# =============================================================================
+# Fake ~/.claude/projects environment
+# =============================================================================
+
+
+def _sanitize(p: str) -> str:
+    return paths._sanitize_path(p)
+
+
+@pytest.fixture
+def fake_claude(tmp_path, monkeypatch):
+    """A tmp CLAUDE_CONFIG_DIR with no git (each cwd pools as its own project).
+
+    Returns a helper object with `.project_dir(path)` to get the encoded dir for
+    a project path and `.write_session(...)` to lay down a session transcript.
+    """
+    config = tmp_path / ".claude"
+    (config / "projects").mkdir(parents=True)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config))
+    # No git anywhere → _get_worktree_paths returns [] → single-dir pooling.
+    monkeypatch.setattr(paths, "_get_worktree_paths", lambda cwd: [])
+    # Identity canonicalize so our synthetic absolute cwds stay stable.
+    monkeypatch.setattr(paths, "_canonicalize_path", lambda p: p)
+
+    class Env:
+        projects_root = config / "projects"
+
+        def project_dir(self, project_path: str) -> Path:
+            return self.projects_root / _sanitize(project_path)
+
+        def write_session(self, session_id: str, lines: list[dict], project_path: str = PROJECT) -> Path:
+            for l in lines:
+                l.setdefault("cwd", project_path)
+                l["sessionId"] = session_id
+            d = self.project_dir(project_path)
+            d.mkdir(parents=True, exist_ok=True)
+            path = d / f"{session_id}.jsonl"
+            _write_jsonl(path, lines)
+            return path
+
+    return Env()
+
+
+SID_A = "aaaaaaaa-1111-2222-3333-444444444444"
+SID_PARENT = "bbbbbbbb-1111-2222-3333-444444444444"
+
+
+def _simple_session_lines() -> list[dict]:
+    return [
+        _user("u1111111-0000-0000-0000-000000000001", "ALPHA question"),
+        _assistant("a1111111-0000-0000-0000-000000000002", "BETA answer", parent="u1111111-0000-0000-0000-000000000001"),
+        _user("u1111111-0000-0000-0000-000000000003", "GAMMA followup", parent="a1111111-0000-0000-0000-000000000002"),
+        _assistant("a1111111-0000-0000-0000-000000000004", "DELTA reply", parent="u1111111-0000-0000-0000-000000000003"),
+    ]
+
+
+def _convo_texts(lines: list[dict]) -> list[str]:
+    """Ordered conversation text of user/assistant lines."""
+    out = []
+    for l in lines:
+        if l.get("type") not in ("user", "assistant"):
+            continue
+        content = l["message"]["content"]
+        if isinstance(content, str):
+            out.append(content)
+        else:
+            out.append("".join(b.get("text", "") for b in content if b.get("type") == "text"))
+    return out
+
+
+# =============================================================================
+# session_to_subagent
+# =============================================================================
+
+
+def test_session_to_subagent_basic(fake_claude):
+    fake_claude.write_session(SID_A, _simple_session_lines())
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+
+    resp = srv.convert_session(
+        direction="session_to_subagent",
+        src_id=SID_A,
+        src_project=PROJECT,
+        dest_parent_session=SID_PARENT,
+    )
+
+    assert resp.operation == "copy"
+    assert resp.direction == "session_to_subagent"
+    assert resp.created_id.startswith("a") and len(resp.created_id) == 17
+    assert resp.invocation == f'SendMessage(to: "{resp.created_id}")'
+    assert resp.parent_session == SID_PARENT
+    assert resp.turns == 4
+    assert resp.tail_state == "clean"
+    assert resp.suggested_handoff and "[CONVERTED SESSION]" in resp.suggested_handoff
+
+    # The new agent transcript lives under the PARENT session's subagents dir.
+    parent_dir = fake_claude.project_dir(PROJECT) / SID_PARENT / "subagents"
+    agent_file = parent_dir / f"agent-{resp.created_id}.jsonl"
+    meta_file = parent_dir / f"agent-{resp.created_id}.meta.json"
+    assert agent_file.exists() and meta_file.exists()
+
+    lines = _read_jsonl(agent_file)
+
+    # The x-converter-provenance line is the FIRST line and the only trust surface.
+    assert lines[0]["type"] == PROVENANCE_TYPE
+    prov = lines[0]["x_converter"]
+    assert prov["tool"] == "convert_session" and prov["v"] == 1
+    assert prov["from"]["kind"] == "session" and prov["from"]["id"] == SID_A
+    assert lines[0]["sessionId"] == SID_PARENT
+    assert lines[0]["agentId"] == resp.created_id
+    # lines_at_creation counts the whole file (provenance line included).
+    assert prov["lines_at_creation"] == len(lines)
+
+    body = _convo_only(lines)
+    assert all(l["isSidechain"] is True for l in body)
+    assert all(l["agentId"] == resp.created_id for l in body)
+    assert all(l["sessionId"] == SID_PARENT for l in body)
+    assert _convo_texts(body) == ["ALPHA question", "BETA answer", "GAMMA followup", "DELTA reply"]
+
+    # meta.json carries ONLY the three standard keys — NO conversion/x_converter
+    # key (the harness rewrites meta.json on resume and drops unknown keys).
+    meta = json.loads(meta_file.read_text())
+    assert set(meta.keys()) == {"agentType", "description", "toolUseId"}
+    assert meta["agentType"] == "general-purpose"
+    assert meta["description"] == f"converted from session {SID_A[:8]} (demo)"
+    assert meta["toolUseId"].startswith("toolu_")
+
+
+def test_session_to_subagent_source_untouched(fake_claude):
+    src = fake_claude.write_session(SID_A, _simple_session_lines())
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    before = src.read_text()
+
+    srv.convert_session(
+        direction="session_to_subagent",
+        src_id=SID_A,
+        src_project=PROJECT,
+        dest_parent_session=SID_PARENT,
+    )
+    assert src.read_text() == before  # never modified
+
+
+def test_session_to_subagent_relinearizes_tree(fake_claude):
+    # A TREE: two assistant siblings off the same user turn (a message edit).
+    lines = [
+        _user("u0000000-0000-0000-0000-000000000001", "ROOT"),
+        _assistant("a0000000-0000-0000-0000-0000000000a1", "EDIT-ONE", parent="u0000000-0000-0000-0000-000000000001"),
+        _assistant("a0000000-0000-0000-0000-0000000000a2", "EDIT-TWO", parent="u0000000-0000-0000-0000-000000000001"),
+        _user("u0000000-0000-0000-0000-000000000003", "NEXT", parent="a0000000-0000-0000-0000-0000000000a2"),
+        _assistant("a0000000-0000-0000-0000-000000000004", "LAST", parent="u0000000-0000-0000-0000-000000000003"),
+    ]
+    fake_claude.write_session(SID_A, lines)
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+
+    resp = srv.convert_session(
+        direction="session_to_subagent",
+        src_id=SID_A, src_project=PROJECT, dest_parent_session=SID_PARENT,
+    )
+    agent_file = fake_claude.project_dir(PROJECT) / SID_PARENT / "subagents" / f"agent-{resp.created_id}.jsonl"
+    all_lines = _read_jsonl(agent_file)
+    assert all_lines[0]["type"] == PROVENANCE_TYPE  # provenance leads
+    out = _convo_only(all_lines)
+
+    # Valid linear chain: first parent null, each subsequent points at predecessor.
+    assert out[0]["parentUuid"] is None
+    for prev, cur in zip(out, out[1:]):
+        assert cur["parentUuid"] == prev["uuid"]
+    # All five turns preserved in file order (siblings linearized, not dropped).
+    assert len(out) == 5
+
+
+def test_session_to_subagent_trims_trailing_noise(fake_claude):
+    lines = _simple_session_lines() + [
+        _user("u9999999-0000-0000-0000-000000000099", "[Request interrupted by user]"),
+        _user("u9999999-0000-0000-0000-00000000009a", ""),
+    ]
+    fake_claude.write_session(SID_A, lines)
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+
+    resp = srv.convert_session(
+        direction="session_to_subagent",
+        src_id=SID_A, src_project=PROJECT, dest_parent_session=SID_PARENT,
+    )
+    assert resp.trimmed_trailing == 2
+    assert resp.turns == 4
+    assert resp.tail_state == "clean"
+
+
+def test_session_to_subagent_pending_user_tail(fake_claude):
+    lines = _simple_session_lines() + [
+        _user("u8888888-0000-0000-0000-000000000088", "a real unanswered question"),
+    ]
+    fake_claude.write_session(SID_A, lines)
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+
+    resp = srv.convert_session(
+        direction="session_to_subagent",
+        src_id=SID_A, src_project=PROJECT, dest_parent_session=SID_PARENT,
+    )
+    assert resp.trimmed_trailing == 0
+    assert resp.tail_state == "pending_user_input"
+
+
+def test_session_to_subagent_default_parent_is_calling_session(fake_claude, monkeypatch):
+    fake_claude.write_session(SID_A, _simple_session_lines())
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID_PARENT)
+
+    resp = srv.convert_session(
+        direction="session_to_subagent", src_id=SID_A, src_project=PROJECT,
+    )
+    assert resp.parent_session == SID_PARENT
+
+
+def test_session_to_subagent_errors_without_parent(fake_claude, monkeypatch):
+    fake_claude.write_session(SID_A, _simple_session_lines())
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+    with pytest.raises(ToolError) as exc:
+        srv.convert_session(direction="session_to_subagent", src_id=SID_A, src_project=PROJECT)
+    assert "dest_parent_session is required" in str(exc.value)
+
+
+def test_session_to_subagent_reports_nested_agents(fake_claude):
+    # Source session has one subagent on disk → nested_agents counts it (not copied).
+    src = fake_claude.write_session(SID_A, _simple_session_lines())
+    sub_dir = fake_claude.project_dir(PROJECT) / SID_A / "subagents"
+    nested_agent = "a" + "f" * 16
+    _write_jsonl(
+        sub_dir / f"agent-{nested_agent}.jsonl",
+        [_user("u-nested-0000-0000-0000-00000000000n", "nested work", agentId=nested_agent, isSidechain=True)],
+    )
+    (sub_dir / f"agent-{nested_agent}.meta.json").write_text(
+        json.dumps({"agentType": "Explore", "description": "d", "toolUseId": "toolu_x"})
+    )
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+
+    resp = srv.convert_session(
+        direction="session_to_subagent", src_id=SID_A, src_project=PROJECT, dest_parent_session=SID_PARENT,
+    )
+    assert resp.nested_agents == 1
+
+
+# =============================================================================
+# subagent_to_session
+# =============================================================================
+
+
+def _lay_down_subagent(
+    fake_claude,
+    agent_id: str,
+    *,
+    is_conversion=False,
+    lines=None,
+    extra_lines=0,
+) -> Path:
+    """Write a subagent transcript (+meta) under SID_PARENT's subagents dir.
+
+    When `is_conversion` is True the file is stamped with a real x-converter-
+    provenance line at the top (the only trust surface) — its lines_at_creation
+    matches the file as written so the growth guard sees no growth. Pass
+    `extra_lines` to append N junk lines AFTER recording lines_at_creation,
+    simulating a resumed/built-upon conversion (growth guard should then refuse).
+    meta.json carries ONLY the three standard keys — never a conversion key.
+    """
+    sub_dir = fake_claude.project_dir(PROJECT) / SID_PARENT / "subagents"
+    body = lines if lines is not None else [
+        _user("u-sub-0000-0000-0000-0000000000s1", "SUBALPHA", agentId=agent_id, isSidechain=True),
+        _assistant("a-sub-0000-0000-0000-0000000000s2", "SUBBETA", parent="u-sub-0000-0000-0000-0000000000s1", agentId=agent_id, isSidechain=True),
+    ]
+
+    out_lines: list[dict]
+    if is_conversion:
+        # lines_at_creation = provenance line + body (what we write now).
+        created = 1 + len(body)
+        prov = _fake_provenance_line(agent_id, lines_at_creation=created)
+        out_lines = [prov] + body
+    else:
+        out_lines = list(body)
+
+    # Simulate resume/build-up: append junk lines NOT counted in lines_at_creation.
+    for i in range(extra_lines):
+        out_lines.append(
+            _user(f"u-grow-0000-0000-0000-00000000g{i:03d}", f"GROWTH{i}", agentId=agent_id, isSidechain=True)
+        )
+
+    _write_jsonl(sub_dir / f"agent-{agent_id}.jsonl", out_lines)
+    # meta.json: standard three keys ONLY (no conversion key — it's not trusted).
+    meta = {"agentType": "general-purpose", "description": "d", "toolUseId": "toolu_abc"}
+    (sub_dir / f"agent-{agent_id}.meta.json").write_text(json.dumps(meta))
+    return sub_dir / f"agent-{agent_id}.jsonl"
+
+
+AGENT_ID = "a" + "1" * 16
+
+
+def test_subagent_to_session_basic(fake_claude):
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    _lay_down_subagent(fake_claude, AGENT_ID)
+
+    resp = srv.convert_session(direction="subagent_to_session", src_id=AGENT_ID, src_project=PROJECT)
+
+    assert resp.operation == "copy"
+    assert resp.direction == "subagent_to_session"
+    new_session = resp.created_id
+    assert resp.title == f"converted-{AGENT_ID[:8]}"
+    assert resp.invocation.startswith(f"claude -r {new_session}")
+    assert "--resume" in resp.invocation
+
+    out_path = fake_claude.project_dir(PROJECT) / f"{new_session}.jsonl"
+    assert out_path.exists()
+    out = _read_jsonl(out_path)
+
+    # Header lines first, then the provenance line (after custom-title), then body.
+    assert out[0]["type"] == "mode"
+    assert out[1]["type"] == "permission-mode"
+    assert out[2]["type"] == "custom-title" and out[2]["customTitle"] == resp.title
+    assert out[3]["type"] == PROVENANCE_TYPE
+    prov = out[3]["x_converter"]
+    assert prov["from"]["kind"] == "subagent" and prov["from"]["id"] == AGENT_ID
+    assert out[3]["sessionId"] == new_session
+    assert out[3]["agentId"] is None  # null for session conversions
+    assert prov["lines_at_creation"] == len(out)  # whole file, provenance included
+    body = [l for l in out if l.get("type") in ("user", "assistant")]
+    assert all(l["isSidechain"] is False for l in body)
+    assert all("agentId" not in l for l in body)
+    assert all(l["sessionId"] == new_session for l in body)
+    # Filename equals internal sessionId.
+    assert out_path.stem == new_session
+    assert _convo_texts(body) == ["SUBALPHA", "SUBBETA"]
+
+
+def test_subagent_to_session_explicit_dest_project(fake_claude):
+    """dest_project routes the new session into a different project's dir."""
+    dest = "/Users/test/projects/dest"
+    fake_claude.write_session(SID_PARENT, _simple_session_lines(), project_path=PROJECT)
+    # Seed the dest project so it has a main-worktree dir to write into.
+    fake_claude.write_session("eeeeeeee-1111-2222-3333-444444444444", _simple_session_lines(), project_path=dest)
+    _lay_down_subagent(fake_claude, AGENT_ID)
+
+    resp = srv.convert_session(
+        direction="subagent_to_session", src_id=AGENT_ID, src_project=PROJECT, dest_project=dest,
+    )
+    assert resp.project == dest
+    assert (fake_claude.project_dir(dest) / f"{resp.created_id}.jsonl").exists()
+    assert not (fake_claude.project_dir(PROJECT) / f"{resp.created_id}.jsonl").exists()
+
+
+def test_subagent_to_session_custom_title(fake_claude):
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    _lay_down_subagent(fake_claude, AGENT_ID)
+
+    resp = srv.convert_session(
+        direction="subagent_to_session", src_id=AGENT_ID, src_project=PROJECT, dest_title="my-special-title",
+    )
+    assert resp.title == "my-special-title"
+
+
+def test_subagent_to_session_title_collision_raises(fake_claude):
+    # A session already carrying the custom title "taken-title".
+    titled = _simple_session_lines()
+    fake_claude.write_session(
+        SID_PARENT,
+        [{"type": "custom-title", "customTitle": "taken-title", "sessionId": SID_PARENT}] + titled,
+    )
+    _lay_down_subagent(fake_claude, AGENT_ID)
+
+    with pytest.raises(ToolError) as exc:
+        srv.convert_session(
+            direction="subagent_to_session", src_id=AGENT_ID, src_project=PROJECT, dest_title="taken-title",
+        )
+    assert "already exists" in str(exc.value).lower()
+
+
+def test_subagent_to_session_refuses_overwrite(fake_claude, monkeypatch):
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    _lay_down_subagent(fake_claude, AGENT_ID)
+
+    # Force convert_subagent_to_session to mint a uuid that already exists on disk.
+    existing = "cccccccc-1111-2222-3333-444444444444"
+    fake_claude.write_session(existing, _simple_session_lines())
+    import cc_explorer.conversion as conv
+    monkeypatch.setattr(conv.uuid, "uuid4", lambda: existing)
+
+    with pytest.raises(ToolError) as exc:
+        srv.convert_session(direction="subagent_to_session", src_id=AGENT_ID, src_project=PROJECT)
+    assert "overwrite" in str(exc.value).lower()
+
+
+# =============================================================================
+# Roundtrip fidelity
+# =============================================================================
+
+
+def test_roundtrip_preserves_conversation_text(fake_claude, monkeypatch):
+    fake_claude.write_session(SID_A, _simple_session_lines())
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+
+    # session -> subagent
+    r1 = srv.convert_session(
+        direction="session_to_subagent", src_id=SID_A, src_project=PROJECT, dest_parent_session=SID_PARENT,
+    )
+    agent_file = fake_claude.project_dir(PROJECT) / SID_PARENT / "subagents" / f"agent-{r1.created_id}.jsonl"
+    mid_texts = _convo_texts(_read_jsonl(agent_file))
+
+    # subagent -> session
+    r2 = srv.convert_session(direction="subagent_to_session", src_id=r1.created_id, src_project=PROJECT)
+    out_path = fake_claude.project_dir(PROJECT) / f"{r2.created_id}.jsonl"
+    final_body = [l for l in _read_jsonl(out_path) if l.get("type") in ("user", "assistant")]
+    final_texts = _convo_texts(final_body)
+
+    assert mid_texts == ["ALPHA question", "BETA answer", "GAMMA followup", "DELTA reply"]
+    assert final_texts == mid_texts  # text survives both hops
+
+
+def test_lineage_accumulates_across_two_conversions(fake_claude):
+    fake_claude.write_session(SID_A, _simple_session_lines())
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+
+    r1 = srv.convert_session(
+        direction="session_to_subagent", src_id=SID_A, src_project=PROJECT, dest_parent_session=SID_PARENT,
+    )
+    assert r1.lineage == [
+        {"as": "session", "id": SID_A},
+        {"as": "subagent", "id": r1.created_id},
+    ]
+
+    r2 = srv.convert_session(direction="subagent_to_session", src_id=r1.created_id, src_project=PROJECT)
+    # Prior chain preserved + the new subagent->session hop appended.
+    assert r2.lineage == [
+        {"as": "session", "id": SID_A},
+        {"as": "subagent", "id": r1.created_id},
+        {"as": "subagent", "id": r1.created_id},
+        {"as": "session", "id": r2.created_id},
+    ]
+
+
+def test_handoff_reflects_subagent_born_source(fake_claude):
+    """A session that was itself converted from a subagent gets the subagent-origin handoff."""
+    fake_claude.write_session(SID_A, _simple_session_lines())
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+
+    r1 = srv.convert_session(
+        direction="session_to_subagent", src_id=SID_A, src_project=PROJECT, dest_parent_session=SID_PARENT,
+    )
+    r2 = srv.convert_session(direction="subagent_to_session", src_id=r1.created_id, src_project=PROJECT)
+    # Now convert that session BACK into a subagent — its source lineage ends on a
+    # subagent hop, so the handoff phrases its origin as a subagent run.
+    r3 = srv.convert_session(
+        direction="session_to_subagent", src_id=r2.created_id, src_project=PROJECT, dest_parent_session=SID_PARENT,
+    )
+    assert r3.suggested_handoff is not None
+    assert "was a subagent run inside Claude Code session" in r3.suggested_handoff
+
+
+# =============================================================================
+# Resolution / ambiguity
+# =============================================================================
+
+
+def test_prefix_ambiguity_raises(fake_claude):
+    # Two sessions sharing an 8-char prefix.
+    s1 = "dddddddd-1111-2222-3333-444444444444"
+    s2 = "dddddddd-9999-8888-7777-666666666666"
+    fake_claude.write_session(s1, _simple_session_lines())
+    fake_claude.write_session(s2, _simple_session_lines())
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+
+    with pytest.raises(ToolError) as exc:
+        srv.convert_session(
+            direction="session_to_subagent", src_id="dddddddd", src_project=PROJECT, dest_parent_session=SID_PARENT,
+        )
+    assert "ambiguous" in str(exc.value).lower()
+
+
+def test_cross_project_src_resolution(fake_claude):
+    """src_project omitted → source located across all projects."""
+    other = "/Users/test/projects/other"
+    fake_claude.write_session(SID_A, _simple_session_lines(), project_path=other)
+    fake_claude.write_session(SID_PARENT, _simple_session_lines(), project_path=PROJECT)
+
+    resp = srv.convert_session(
+        direction="session_to_subagent", src_id=SID_A, dest_parent_session=SID_PARENT,
+    )
+    # The source was found in `other` even though the parent is in PROJECT.
+    parent_dir = fake_claude.project_dir(PROJECT) / SID_PARENT / "subagents"
+    assert (parent_dir / f"agent-{resp.created_id}.jsonl").exists()
+
+
+# =============================================================================
+# delete_conversions
+# =============================================================================
+
+
+def test_delete_conversions_removes_tagged_subagent(fake_claude):
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    conv_agent = "a" + "2" * 16
+    path = _lay_down_subagent(fake_claude, conv_agent, is_conversion=True)
+    assert path.exists()
+
+    resp = srv.delete_conversions(ids=[conv_agent])
+    assert len(resp.deleted) == 1
+    assert resp.deleted[0].kind == "subagent"
+    assert not resp.refused
+    assert not path.exists()
+    assert not path.with_suffix(".meta.json").exists()
+
+
+def test_delete_conversions_refuses_subagent_without_provenance_line(fake_claude):
+    """No provenance line (meta is no longer a signal) → refused as non-conversion."""
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    real_agent = "a" + "3" * 16
+    path = _lay_down_subagent(fake_claude, real_agent, is_conversion=False)
+
+    resp = srv.delete_conversions(ids=[real_agent])
+    assert not resp.deleted
+    assert len(resp.refused) == 1
+    assert "not a conversion artifact" in resp.refused[0].reason
+    assert "x-converter-provenance" in resp.refused[0].reason
+    assert path.exists()  # untouched
+
+
+def test_delete_conversions_refuses_real_session(fake_claude):
+    """A real (untagged) session resolves as a session → refused with the session message."""
+    fake_claude.write_session(SID_A, _simple_session_lines())
+    resp = srv.delete_conversions(ids=[SID_A])
+    assert not resp.deleted
+    assert len(resp.refused) == 1
+    assert "converted sessions are for humans to manage" in resp.refused[0].reason
+    assert (fake_claude.project_dir(PROJECT) / f"{SID_A}.jsonl").exists()
+
+
+def test_delete_conversions_refuses_converted_session_even_when_tagged(fake_claude):
+    """Sessions are NEVER deleted by this tool — even a genuine, provenance-tagged one."""
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    _lay_down_subagent(fake_claude, AGENT_ID, is_conversion=True)
+    r = srv.convert_session(direction="subagent_to_session", src_id=AGENT_ID, src_project=PROJECT)
+    out_path = fake_claude.project_dir(PROJECT) / f"{r.created_id}.jsonl"
+    assert out_path.exists()
+    # Sanity: it really IS a tagged conversion (the file carries a provenance line).
+    from cc_explorer.conversion import is_conversion as _is_conv
+    assert _is_conv(out_path)
+
+    resp = srv.delete_conversions(ids=[r.created_id])
+    assert not resp.deleted
+    assert len(resp.refused) == 1
+    assert "converted sessions are for humans to manage" in resp.refused[0].reason
+    assert out_path.exists()  # untouched
+
+
+def test_delete_conversions_refuses_grown_subagent(fake_claude):
+    """Growth guard: a tagged subagent that grew past lines_at_creation is refused."""
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    grown = "a" + "9" * 16
+    path = _lay_down_subagent(fake_claude, grown, is_conversion=True, extra_lines=3)
+
+    resp = srv.delete_conversions(ids=[grown])
+    assert not resp.deleted
+    assert len(resp.refused) == 1
+    assert "resumed or built upon" in resp.refused[0].reason
+    assert path.exists()  # untouched — someone may depend on it
+
+
+def test_delete_conversions_deletes_subagent_when_growth_guard_passes(fake_claude):
+    """Provenance line present AND no growth → deleted."""
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    conv_agent = "a" + "2" * 16
+    path = _lay_down_subagent(fake_claude, conv_agent, is_conversion=True, extra_lines=0)
+    assert path.exists()
+
+    resp = srv.delete_conversions(ids=[conv_agent])
+    assert len(resp.deleted) == 1
+    assert resp.deleted[0].kind == "subagent"
+    assert not resp.refused
+    assert not path.exists()
+    assert not path.with_suffix(".meta.json").exists()
+
+
+def test_delete_conversions_unknown_id_refused(fake_claude):
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    resp = srv.delete_conversions(ids=["nonexistent-id-xyz"])
+    assert not resp.deleted
+    assert len(resp.refused) == 1
+    assert "no session or subagent" in resp.refused[0].reason
+
+
+def test_delete_conversions_sweep_calling_session(fake_claude, monkeypatch):
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    conv_a = "a" + "4" * 16
+    real_a = "a" + "5" * 16
+    grown_a = "a" + "6" * 16
+    conv_path = _lay_down_subagent(fake_claude, conv_a, is_conversion=True)
+    real_path = _lay_down_subagent(fake_claude, real_a, is_conversion=False)
+    grown_path = _lay_down_subagent(fake_claude, grown_a, is_conversion=True, extra_lines=2)
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID_PARENT)
+
+    resp = srv.delete_conversions()  # ids omitted → sweep
+    deleted_ids = {d.id for d in resp.deleted}
+    refused_ids = {r.id for r in resp.refused}
+    assert conv_a in deleted_ids
+    assert real_a not in deleted_ids  # untagged: never touched, not even reported
+    assert grown_a in refused_ids  # tagged but grown → reported as skipped
+    assert not conv_path.exists()
+    assert real_path.exists()  # non-conversion agent untouched
+    assert grown_path.exists()  # grown conversion untouched
+    # The growth-guard skip carries the resume/build-up reason.
+    grown_reason = next(r.reason for r in resp.refused if r.id == grown_a)
+    assert "resumed or built upon" in grown_reason
+
+
+# =============================================================================
+# Search corpus exclusion + list_session_agents labeling
+# =============================================================================
+
+
+def test_conversion_agent_excluded_from_search_corpus(fake_claude):
+    session_path = fake_claude.write_session(SID_PARENT, [_user("u-main-0000-0000-0000-00000000m001", "MAINONLY")])
+    # A conversion subagent containing a unique token.
+    conv_agent = "a" + "6" * 16
+    _lay_down_subagent(
+        fake_claude, conv_agent, is_conversion=True,
+        lines=[_user("u-conv-0000-0000-0000-00000000c001", "SECRETTOKEN", agentId=conv_agent, isSidechain=True)],
+    )
+    # A normal subagent containing a different unique token.
+    real_agent = "a" + "7" * 16
+    _lay_down_subagent(
+        fake_claude, real_agent, is_conversion=False,
+        lines=[_user("u-real-0000-0000-0000-00000000r001", "VISIBLETOKEN", agentId=real_agent, isSidechain=True)],
+    )
+
+    session = SessionInfo(
+        session_id=PrefixId(SID_PARENT), path=session_path, title="t",
+        first_timestamp=None, message_count=1, project_path=PROJECT,
+    )
+
+    # session_sources excludes the conversion agent's file.
+    src_paths = {s.path for s in session_sources(session)}
+    assert _lay_down_subagent.__name__  # sanity
+    assert (fake_claude.project_dir(PROJECT) / SID_PARENT / "subagents" / f"agent-{real_agent}.jsonl") in src_paths
+    assert (fake_claude.project_dir(PROJECT) / SID_PARENT / "subagents" / f"agent-{conv_agent}.jsonl") not in src_paths
+
+    # Triage: the conversion token is NOT found, the normal one IS.
+    secret = triage_multi([session], ["SECRETTOKEN"])
+    assert secret[0][1] == []  # no hits
+    visible = triage_multi([session], ["VISIBLETOKEN"])
+    assert len(visible[0][1]) == 1
+
+
+def test_list_session_agents_shows_conversion_labeled(fake_claude):
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    conv_agent = "a" + "8" * 16
+    _lay_down_subagent(fake_claude, conv_agent, is_conversion=True)
+
+    resp = srv.list_session_agents(session=SID_PARENT, projects=[PROJECT])
+    ids = {a.agent_id.full: a for a in resp.agents}
+    assert conv_agent in ids
+    assert ids[conv_agent].is_conversion is True

--- a/project-mining/tests/test_conversion.py
+++ b/project-mining/tests/test_conversion.py
@@ -266,6 +266,9 @@ def test_session_to_subagent_source_untouched(fake_claude):
 
 def test_session_to_subagent_relinearizes_tree(fake_claude):
     # A TREE: two assistant siblings off the same user turn (a message edit).
+    # EDIT-ONE is an abandoned branch; EDIT-TWO is the active branch (the last
+    # user and assistant turns continue from it). The active-thread extraction
+    # walks parentUuid backward from the tip, so EDIT-ONE is DROPPED.
     lines = [
         _user("u0000000-0000-0000-0000-000000000001", "ROOT"),
         _assistant("a0000000-0000-0000-0000-0000000000a1", "EDIT-ONE", parent="u0000000-0000-0000-0000-000000000001"),
@@ -289,8 +292,11 @@ def test_session_to_subagent_relinearizes_tree(fake_claude):
     assert out[0]["parentUuid"] is None
     for prev, cur in zip(out, out[1:]):
         assert cur["parentUuid"] == prev["uuid"]
-    # All five turns preserved in file order (siblings linearized, not dropped).
-    assert len(out) == 5
+    # Active thread: ROOT → EDIT-TWO → NEXT → LAST (4 turns).
+    # EDIT-ONE is the abandoned sibling branch and is DROPPED.
+    assert len(out) == 4
+    assert _convo_texts(out) == ["ROOT", "EDIT-TWO", "NEXT", "LAST"]
+    assert resp.dropped_branches == 1
 
 
 def test_session_to_subagent_trims_trailing_noise(fake_claude):
@@ -373,13 +379,13 @@ def _lay_down_subagent(
     fake_claude,
     agent_id: str,
     *,
-    is_conversion=False,
+    is_conversion_artifact=False,
     lines=None,
     extra_lines=0,
 ) -> Path:
     """Write a subagent transcript (+meta) under SID_PARENT's subagents dir.
 
-    When `is_conversion` is True the file is stamped with a real x-converter-
+    When `is_conversion_artifact` is True the file is stamped with a real x-converter-
     provenance line at the top (the only trust surface) — its lines_at_creation
     matches the file as written so the growth guard sees no growth. Pass
     `extra_lines` to append N junk lines AFTER recording lines_at_creation,
@@ -393,7 +399,7 @@ def _lay_down_subagent(
     ]
 
     out_lines: list[dict]
-    if is_conversion:
+    if is_conversion_artifact:
         # lines_at_creation = provenance line + body (what we write now).
         created = 1 + len(body)
         prov = _fake_provenance_line(agent_id, lines_at_creation=created)
@@ -618,7 +624,7 @@ def test_cross_project_src_resolution(fake_claude):
 def test_delete_conversions_removes_tagged_subagent(fake_claude):
     fake_claude.write_session(SID_PARENT, _simple_session_lines())
     conv_agent = "a" + "2" * 16
-    path = _lay_down_subagent(fake_claude, conv_agent, is_conversion=True)
+    path = _lay_down_subagent(fake_claude, conv_agent, is_conversion_artifact=True)
     assert path.exists()
 
     resp = srv.delete_conversions(ids=[conv_agent])
@@ -633,7 +639,7 @@ def test_delete_conversions_refuses_subagent_without_provenance_line(fake_claude
     """No provenance line (meta is no longer a signal) → refused as non-conversion."""
     fake_claude.write_session(SID_PARENT, _simple_session_lines())
     real_agent = "a" + "3" * 16
-    path = _lay_down_subagent(fake_claude, real_agent, is_conversion=False)
+    path = _lay_down_subagent(fake_claude, real_agent, is_conversion_artifact=False)
 
     resp = srv.delete_conversions(ids=[real_agent])
     assert not resp.deleted
@@ -656,12 +662,12 @@ def test_delete_conversions_refuses_real_session(fake_claude):
 def test_delete_conversions_refuses_converted_session_even_when_tagged(fake_claude):
     """Sessions are NEVER deleted by this tool — even a genuine, provenance-tagged one."""
     fake_claude.write_session(SID_PARENT, _simple_session_lines())
-    _lay_down_subagent(fake_claude, AGENT_ID, is_conversion=True)
+    _lay_down_subagent(fake_claude, AGENT_ID, is_conversion_artifact=True)
     r = srv.convert_session(direction="subagent_to_session", src_id=AGENT_ID, src_project=PROJECT)
     out_path = fake_claude.project_dir(PROJECT) / f"{r.created_id}.jsonl"
     assert out_path.exists()
     # Sanity: it really IS a tagged conversion (the file carries a provenance line).
-    from cc_explorer.conversion import is_conversion as _is_conv
+    from cc_explorer.conversion import is_conversion_artifact as _is_conv
     assert _is_conv(out_path)
 
     resp = srv.delete_conversions(ids=[r.created_id])
@@ -675,7 +681,7 @@ def test_delete_conversions_refuses_grown_subagent(fake_claude):
     """Growth guard: a tagged subagent that grew past lines_at_creation is refused."""
     fake_claude.write_session(SID_PARENT, _simple_session_lines())
     grown = "a" + "9" * 16
-    path = _lay_down_subagent(fake_claude, grown, is_conversion=True, extra_lines=3)
+    path = _lay_down_subagent(fake_claude, grown, is_conversion_artifact=True, extra_lines=3)
 
     resp = srv.delete_conversions(ids=[grown])
     assert not resp.deleted
@@ -688,7 +694,7 @@ def test_delete_conversions_deletes_subagent_when_growth_guard_passes(fake_claud
     """Provenance line present AND no growth → deleted."""
     fake_claude.write_session(SID_PARENT, _simple_session_lines())
     conv_agent = "a" + "2" * 16
-    path = _lay_down_subagent(fake_claude, conv_agent, is_conversion=True, extra_lines=0)
+    path = _lay_down_subagent(fake_claude, conv_agent, is_conversion_artifact=True, extra_lines=0)
     assert path.exists()
 
     resp = srv.delete_conversions(ids=[conv_agent])
@@ -712,9 +718,9 @@ def test_delete_conversions_sweep_calling_session(fake_claude, monkeypatch):
     conv_a = "a" + "4" * 16
     real_a = "a" + "5" * 16
     grown_a = "a" + "6" * 16
-    conv_path = _lay_down_subagent(fake_claude, conv_a, is_conversion=True)
-    real_path = _lay_down_subagent(fake_claude, real_a, is_conversion=False)
-    grown_path = _lay_down_subagent(fake_claude, grown_a, is_conversion=True, extra_lines=2)
+    conv_path = _lay_down_subagent(fake_claude, conv_a, is_conversion_artifact=True)
+    real_path = _lay_down_subagent(fake_claude, real_a, is_conversion_artifact=False)
+    grown_path = _lay_down_subagent(fake_claude, grown_a, is_conversion_artifact=True, extra_lines=2)
     monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID_PARENT)
 
     resp = srv.delete_conversions()  # ids omitted → sweep
@@ -741,13 +747,13 @@ def test_conversion_agent_excluded_from_search_corpus(fake_claude):
     # A conversion subagent containing a unique token.
     conv_agent = "a" + "6" * 16
     _lay_down_subagent(
-        fake_claude, conv_agent, is_conversion=True,
+        fake_claude, conv_agent, is_conversion_artifact=True,
         lines=[_user("u-conv-0000-0000-0000-00000000c001", "SECRETTOKEN", agentId=conv_agent, isSidechain=True)],
     )
     # A normal subagent containing a different unique token.
     real_agent = "a" + "7" * 16
     _lay_down_subagent(
-        fake_claude, real_agent, is_conversion=False,
+        fake_claude, real_agent, is_conversion_artifact=False,
         lines=[_user("u-real-0000-0000-0000-00000000r001", "VISIBLETOKEN", agentId=real_agent, isSidechain=True)],
     )
 
@@ -772,9 +778,376 @@ def test_conversion_agent_excluded_from_search_corpus(fake_claude):
 def test_list_session_agents_shows_conversion_labeled(fake_claude):
     fake_claude.write_session(SID_PARENT, _simple_session_lines())
     conv_agent = "a" + "8" * 16
-    _lay_down_subagent(fake_claude, conv_agent, is_conversion=True)
+    _lay_down_subagent(fake_claude, conv_agent, is_conversion_artifact=True)
 
     resp = srv.list_session_agents(session=SID_PARENT, projects=[PROJECT])
     ids = {a.agent_id.full: a for a in resp.agents}
     assert conv_agent in ids
-    assert ids[conv_agent].is_conversion is True
+    assert ids[conv_agent].is_conversion_artifact is True
+
+
+# =============================================================================
+# Fix 1: Trim safety — tool_result user turn never trimmed as noise
+# =============================================================================
+
+
+def _tool_use_assistant(uuid: str, tool_use_id: str, *, parent: str | None = None) -> dict:
+    """An assistant turn ending with a tool_use block (e.g. a pending Bash call)."""
+    line = {
+        "type": "assistant",
+        "uuid": uuid,
+        "parentUuid": parent,
+        "timestamp": TS,
+        "sessionId": "SID",
+        "version": "2.1.175",
+        "gitBranch": "main",
+        "message": {
+            "id": "msg_" + uuid,
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4-8",
+            "content": [
+                {"type": "text", "text": "running tool"},
+                {"type": "tool_use", "id": tool_use_id, "name": "Bash", "input": {"command": "ls"}},
+            ],
+        },
+    }
+    return line
+
+
+def _tool_result_user(uuid: str, tool_use_id: str, *, parent: str | None = None) -> dict:
+    """A user turn carrying ONLY a tool_result block (no text blocks)."""
+    return {
+        "type": "user",
+        "uuid": uuid,
+        "parentUuid": parent,
+        "timestamp": TS,
+        "sessionId": "SID",
+        "version": "2.1.175",
+        "gitBranch": "main",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": [{"type": "text", "text": "file.txt"}],
+                }
+            ],
+        },
+    }
+
+
+def test_trim_safety_tool_result_user_not_trimmed(fake_claude):
+    """A session ending assistant(tool_use)+user(tool_result) must keep BOTH lines.
+
+    Fix 1: a user turn whose content list contains a tool_result block must never
+    be treated as trailing noise, even though its text content is empty. Trimming
+    it would leave a dangling assistant tool_use that the API rejects on resume.
+    """
+    tool_id = "toolu_test0000000000000000"
+    lines = _simple_session_lines() + [
+        _tool_use_assistant(
+            "a-tool-0000-0000-0000-000000000aa1",
+            tool_id,
+            parent="u1111111-0000-0000-0000-000000000003",
+        ),
+        _tool_result_user(
+            "u-tool-0000-0000-0000-000000000ur1",
+            tool_id,
+            parent="a-tool-0000-0000-0000-000000000aa1",
+        ),
+    ]
+    fake_claude.write_session(SID_A, lines)
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+
+    resp = srv.convert_session(
+        direction="session_to_subagent",
+        src_id=SID_A, src_project=PROJECT, dest_parent_session=SID_PARENT,
+    )
+    # Neither the tool_use assistant turn nor the tool_result user turn should be trimmed.
+    assert resp.trimmed_trailing == 0
+    # The copied transcript includes the tool_use and tool_result turns.
+    agent_file = (
+        fake_claude.project_dir(PROJECT) / SID_PARENT / "subagents" / f"agent-{resp.created_id}.jsonl"
+    )
+    body = _convo_only(_read_jsonl(agent_file))
+    types = [l["type"] for l in body]
+    # Ends with user (tool_result turn) — not trimmed.
+    assert types[-1] == "user"
+    # That user turn's content has a tool_result block.
+    last_content = body[-1]["message"]["content"]
+    assert any(b.get("type") == "tool_result" for b in last_content)
+
+
+# =============================================================================
+# Fix 2: Broken-links fallback (parentUuid walk can't complete)
+# =============================================================================
+
+
+def test_active_thread_broken_links_fallback(fake_claude):
+    """When parentUuid links are broken (missing parent), fall back to file order.
+
+    A session where the last line's parent uuid doesn't exist in the corpus
+    causes the walk to fail and fall back to including all lines (file order).
+    """
+    # Build lines where the last line's parentUuid points to a non-existent uuid.
+    lines = [
+        _user("u0000000-1111-0000-0000-000000000001", "FIRST"),
+        _assistant("a0000000-1111-0000-0000-000000000002", "SECOND", parent="u0000000-1111-0000-0000-000000000001"),
+        _user("u0000000-1111-0000-0000-000000000003", "THIRD", parent="a0000000-1111-0000-0000-000000000002"),
+        # This assistant points to a parent that doesn't exist → broken link.
+        _assistant("a0000000-1111-0000-0000-000000000004", "FOURTH",
+                   parent="nonexistent-0000-0000-0000-000000000000"),
+    ]
+    fake_claude.write_session(SID_A, lines)
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+
+    resp = srv.convert_session(
+        direction="session_to_subagent",
+        src_id=SID_A, src_project=PROJECT, dest_parent_session=SID_PARENT,
+    )
+    # Fallback: all 4 lines kept (file order), none dropped.
+    assert resp.turns == 4
+    assert resp.dropped_branches == 0
+
+
+# =============================================================================
+# Fix 3: Source-project provenance stamped correctly for subagent_to_session
+# =============================================================================
+
+
+def test_subagent_to_session_provenance_from_project_is_holding_project(fake_claude):
+    """Provenance from.project == holding project; response.project == dest project.
+
+    Fix 3: before this fix, src_project_path was incorrectly set to dest_proj_path,
+    so provenance/from.project pointed at the destination instead of the source.
+    """
+    dest = "/Users/test/projects/dest"
+    # Seed the dest project so it has a dir to write into.
+    fake_claude.write_session("eeeeeeee-1111-2222-3333-444444444444", _simple_session_lines(), project_path=dest)
+    fake_claude.write_session(SID_PARENT, _simple_session_lines(), project_path=PROJECT)
+    _lay_down_subagent(fake_claude, AGENT_ID)
+
+    resp = srv.convert_session(
+        direction="subagent_to_session",
+        src_id=AGENT_ID,
+        src_project=PROJECT,
+        dest_project=dest,
+    )
+    # response.project is the DESTINATION.
+    assert resp.project == dest
+
+    # The written file's provenance/from.project is the HOLDING (source) project.
+    out_path = fake_claude.project_dir(dest) / f"{resp.created_id}.jsonl"
+    assert out_path.exists()
+    lines = _read_jsonl(out_path)
+    prov_lines = _provenance_lines(lines)
+    assert len(prov_lines) == 1
+    from_project = prov_lines[0]["x_converter"]["from"]["project"]
+    assert from_project == PROJECT  # holding project, not dest
+    assert from_project != dest
+
+
+# =============================================================================
+# Fix 4: Session conversion artifacts excluded from search but visible in listing
+# =============================================================================
+
+
+def test_session_conversion_artifact_excluded_from_search(fake_claude):
+    """A subagent_to_session artifact is excluded from triage/search results.
+
+    Fix 4: session conversion artifacts (session files carrying x-converter-provenance)
+    should be skipped in search/triage, just like agent-shaped conversion artifacts.
+    """
+    # A normal session with a unique token.
+    normal_sid = "cccccccc-aaaa-0000-0000-000000000001"
+    fake_claude.write_session(
+        normal_sid,
+        [_user("u-norm-0000-0000-0000-0000000n0001", "NORMALTOKEN")],
+    )
+    # A subagent_to_session conversion artifact: has x-converter-provenance header.
+    conv_sid = "cccccccc-bbbb-0000-0000-000000000002"
+    conv_lines = [
+        {"type": "mode", "mode": "normal", "sessionId": conv_sid},
+        {"type": "permission-mode", "permissionMode": "default", "sessionId": conv_sid},
+        {"type": "custom-title", "customTitle": "conv-session", "sessionId": conv_sid},
+        {
+            "type": "x-converter-provenance",
+            "x_converter": {
+                "tool": "convert_session",
+                "v": 1,
+                "from": {"kind": "subagent", "id": "x", "project": PROJECT},
+                "converted_at": TS,
+                "lines_at_creation": 6,
+            },
+            "sessionId": conv_sid,
+            "agentId": None,
+        },
+        _user("u-conv-0000-0000-0000-0000000c0001", "SECRETTOKEN"),
+        _assistant("a-conv-0000-0000-0000-0000000c0002", "reply"),
+    ]
+    for l in conv_lines:
+        l.setdefault("cwd", PROJECT)
+    d = fake_claude.project_dir(PROJECT)
+    d.mkdir(parents=True, exist_ok=True)
+    _write_jsonl(d / f"{conv_sid}.jsonl", conv_lines)
+
+    sessions, _ = srv._load_all_sessions([PROJECT])
+
+    # Triage: conversion artifact session not in search results.
+    from cc_explorer.search import triage_multi
+    secret = triage_multi(sessions, ["SECRETTOKEN"])
+    assert secret[0][1] == []  # no hits from conversion artifact session
+    normal = triage_multi(sessions, ["NORMALTOKEN"])
+    assert len(normal[0][1]) == 1  # normal session found
+
+
+def test_session_conversion_artifact_labeled_in_listing(fake_claude):
+    """A subagent_to_session artifact appears in list_project_sessions with is_conversion_artifact=true."""
+    # Normal session (different prefix from conversion session).
+    normal_sid = "11111111-aaaa-0000-0000-000000000001"
+    fake_claude.write_session(normal_sid, _simple_session_lines())
+
+    # A subagent_to_session conversion artifact.
+    conv_sid = "22222222-bbbb-0000-0000-000000000002"
+    conv_lines = [
+        {"type": "mode", "mode": "normal", "sessionId": conv_sid},
+        {"type": "permission-mode", "permissionMode": "default", "sessionId": conv_sid},
+        {"type": "custom-title", "customTitle": "labeled-conv", "sessionId": conv_sid},
+        {
+            "type": "x-converter-provenance",
+            "x_converter": {
+                "tool": "convert_session",
+                "v": 1,
+                "from": {"kind": "subagent", "id": "x", "project": PROJECT},
+                "converted_at": TS,
+                "lines_at_creation": 6,
+            },
+            "sessionId": conv_sid,
+            "agentId": None,
+        },
+        _user("u-lbl-0000-0000-0000-0000000l0001", "hello"),
+        _assistant("a-lbl-0000-0000-0000-0000000l0002", "world"),
+    ]
+    for l in conv_lines:
+        l.setdefault("cwd", PROJECT)
+    d = fake_claude.project_dir(PROJECT)
+    d.mkdir(parents=True, exist_ok=True)
+    _write_jsonl(d / f"{conv_sid}.jsonl", conv_lines)
+
+    resp = srv.list_project_sessions(projects=[PROJECT], min_messages=1)
+    by_id = {str(s.session)[:8]: s for s in resp.sessions}
+    # Both sessions are listed.
+    assert conv_sid[:8] in by_id
+    assert normal_sid[:8] in by_id
+    # The artifact is labeled.
+    assert by_id[conv_sid[:8]].is_conversion_artifact is True
+    assert by_id[normal_sid[:8]].is_conversion_artifact is None
+
+
+# =============================================================================
+# Fix 5: Delete resolution hardening
+# =============================================================================
+
+
+def test_delete_conversions_short_id_rejected(fake_claude):
+    """An id shorter than 6 chars is rejected with a clear error before any lookup."""
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    with pytest.raises(ToolError) as exc:
+        srv.delete_conversions(ids=["ab"])
+    assert "too short" in str(exc.value).lower()
+
+
+def test_delete_conversions_ambiguous_prefix_raises(fake_claude):
+    """An ambiguous prefix (matches multiple distinct artifacts) raises ToolError naming candidates."""
+    # Two sessions whose ids share a prefix.
+    s1 = "eeeeeeee-1111-2222-3333-444444444441"
+    s2 = "eeeeeeee-1111-2222-3333-444444444442"
+    fake_claude.write_session(s1, _simple_session_lines())
+    fake_claude.write_session(s2, _simple_session_lines())
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+
+    with pytest.raises(ToolError) as exc:
+        srv.delete_conversions(ids=["eeeeeeee"])
+    assert "ambiguous" in str(exc.value).lower()
+
+
+# =============================================================================
+# Fix 6: Sweep error swallow
+# =============================================================================
+
+
+def test_delete_conversions_sweep_raises_on_unresolvable_session(fake_claude, monkeypatch):
+    """Sweep with an unresolvable calling session raises ToolError (not empty success).
+
+    Fix 6: the old behavior silently returned empty deleted/refused on resolution
+    failure, making it indistinguishable from 'nothing to clean'.
+    """
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    # Point the calling session to something that doesn't exist.
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "nonexistent-0000-0000-0000-000000000000")
+    with pytest.raises(ToolError) as exc:
+        srv.delete_conversions()
+    assert "sweep failed" in str(exc.value).lower() or "could not resolve" in str(exc.value).lower()
+
+
+# =============================================================================
+# Fix 8: Population semantics — conversion artifacts not counted as dispatched runs
+# =============================================================================
+
+
+def test_agents_present_excludes_conversion_artifacts(fake_claude):
+    """A session whose ONLY agent file is a conversion artifact has agents_present==0."""
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    conv_agent = "a" + "c" * 16
+    _lay_down_subagent(fake_claude, conv_agent, is_conversion_artifact=True)
+
+    sessions, _ = srv._load_all_sessions([PROJECT], with_agents_present=True)
+    parent_session = next(s for s in sessions if str(s.session_id) == SID_PARENT[:8] or s.session_id.full == SID_PARENT)
+    assert parent_session.agents_present == 0
+
+
+def test_min_agents_filter_excludes_conversion_only_sessions(fake_claude):
+    """A session with only a conversion artifact is absent from min_agents=1 listings.
+
+    Since agents_present==0 for that session, min_agents=1 filters it out.
+    With no other sessions matching, list_project_sessions raises (nothing to return).
+    """
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    conv_agent = "a" + "d" * 16
+    _lay_down_subagent(fake_claude, conv_agent, is_conversion_artifact=True)
+
+    # With min_agents=1, the session (agents_present==0) doesn't match — nothing returned.
+    with pytest.raises(ToolError):
+        srv.list_project_sessions(projects=[PROJECT], min_agents=1, min_messages=1)
+
+    # With min_agents=0, the session is present (no filtering on agents).
+    resp = srv.list_project_sessions(projects=[PROJECT], min_agents=0, min_messages=1)
+    session_ids = {s.session.full for s in resp.sessions}
+    assert SID_PARENT in session_ids
+
+
+def test_nested_agents_excludes_conversion_artifacts(fake_claude):
+    """convert_session's nested_agents count excludes conversion artifacts on the source."""
+    fake_claude.write_session(SID_A, _simple_session_lines())
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+
+    # Put a conversion artifact under SID_A (not a real dispatched run).
+    conv_nested = "a" + "e" * 16
+    sub_dir = fake_claude.project_dir(PROJECT) / SID_A / "subagents"
+    body = [
+        _user("u-n-0000-0000-0000-0000000n0001", "n", agentId=conv_nested, isSidechain=True),
+    ]
+    prov = _fake_provenance_line(conv_nested, lines_at_creation=2, kind="session")
+    _write_jsonl(sub_dir / f"agent-{conv_nested}.jsonl", [prov] + body)
+    (sub_dir / f"agent-{conv_nested}.meta.json").write_text(
+        json.dumps({"agentType": "general-purpose", "description": "d", "toolUseId": "toolu_n"})
+    )
+
+    resp = srv.convert_session(
+        direction="session_to_subagent",
+        src_id=SID_A, src_project=PROJECT, dest_parent_session=SID_PARENT,
+    )
+    # Conversion artifact is not counted as a nested agent.
+    assert resp.nested_agents is None or resp.nested_agents == 0

--- a/project-mining/uv.lock
+++ b/project-mining/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "cc-explorer"
-version = "1.33.0"
+version = "1.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/project-mining/uv.lock
+++ b/project-mining/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "cc-explorer"
-version = "1.34.0"
+version = "1.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Closes #29.

## What

Two new MCP tools on the cc-explorer server, plus skill teaching:

- **`convert_session(direction, src_id, src_project?, dest_parent_session?, dest_title?, dest_project?)`** — copy a session into a resumable subagent (`session_to_subagent`), or a subagent out to a top-level session a human can `claude -r` into (`subagent_to_session`). Always a copy; the source transcript is never modified, moved, or deleted. The response carries everything needed to compose the first message: a `suggested_handoff` note, the original environment (cwd/branch existence checks, CC version, age), model history, turn count, tail state, and lineage.
- **`delete_conversions(ids?)`** — removes conversion-tagged subagents and nothing else. Refuses sessions unconditionally, refuses untagged artifacts, refuses anything that grew past `lines_at_creation` (someone may depend on it). Sweep mode cleans the calling session.

Integration: conversion artifacts are excluded from the search corpus (no double-counting) and labeled in `list_session_agents`.

## Design receipts (from the spike + this session's live experiments)

- **Trust surface**: the `x-converter-provenance` jsonl line is the *only* durable marker. A live probe showed the harness rewrites agent `meta.json` on SendMessage-resume, silently dropping unknown keys, while an own-type line survives byte-intact. The growth-guard baseline lives in that line.
- **Handoff note**: the wire format proves SendMessage content arrives unlabeled — a converted conversation has no way to know its interlocutor changed. That one fact is the entire prescribed preamble; everything else (stance, tool rules, environment briefing) is the invoker's choice, taught as considerations in the skill.
- **Model**: resumed agents inherit the calling session's model; the transcript's model is not honored (haiku-born source answered as the host's model). Surfaced via `models` in the response.
- Transcript trees are relinearized; trailing harness noise (`/exit` records, interrupt sentinels) is trimmed; fabricated assistant lines are never written (`<synthetic>` retag).

## Tests

`311 passed` + 28 new conversion tests, all-synthesized fixtures (no conversation content — public repo). One pre-existing unrelated failure (`test_worktree_unification.py::test_no_git_falls_back_to_single_dir`, fails on main too — issue to follow).

Live smoke: converted a real session, resumed it via SendMessage (correct one-sentence recall), verified provenance survival, growth-guard refusal after resume, clean delete of an unresumed conversion, and refusal of a real (non-conversion) agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)