### PR TITLE
feat(cc-explorer): rewind_transcript — truncate a conversion artifact in place to an earlier turn

### DIFF
--- a/project-mining/.claude-plugin/plugin.json
+++ b/project-mining/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-mining",
-  "version": "2.45.0",
+  "version": "2.46.0",
   "description": "Mine project histories for behavioral evidence. Search chat logs, git history, docs, and code for concrete examples of specific patterns, values, or skills.",
   "author": {
     "name": "Cory King",

--- a/project-mining/pyproject.toml
+++ b/project-mining/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-explorer"
-version = "1.36.0"
+version = "1.37.0"
 description = "MCP server for exploring Claude Code chat history — search conversations, quote moments, inspect subagents."
 requires-python = ">=3.11"
 dependencies = [

--- a/project-mining/src/cc_explorer/conversion.py
+++ b/project-mining/src/cc_explorer/conversion.py
@@ -35,6 +35,7 @@ reading; this is surgery on the wire format.
 from __future__ import annotations
 
 import json
+import os
 import secrets
 import uuid
 from collections import Counter
@@ -787,6 +788,259 @@ def convert_subagent_to_session(
         title=dest_title,
         project=src_project_path,
         written_path=out_path,
+    )
+
+
+# =============================================================================
+# Rewind — truncate a conversion artifact in place to an earlier turn
+# =============================================================================
+#
+# Rewind mutates a conversion artifact IN PLACE: it cuts the transcript at a
+# chosen turn, discards everything after the cut, and rewrites the file so the
+# artifact resumes from the earlier point. This is destructive (the discarded
+# tail is gone), which is exactly why it is gated on the x-converter-provenance
+# line: we only ever mutate files WE wrote. A real session or subagent is never
+# touched — the caller refuses anything without provenance before calling here.
+#
+# The structural prefix (session header lines + the provenance line) is preserved
+# verbatim except for the provenance line's `lines_at_creation`, which is
+# re-stamped to the new physical line count so the growth guard and deletion stay
+# coherent (current == created right after a rewind → still deletable, not "grown").
+
+
+def _assistant_has_tool_use(line: dict[str, Any]) -> bool:
+    """True when an assistant line's content carries any tool_use block.
+
+    When such a line is the tail of a truncated transcript, the tool_use has no
+    following tool_result — a dangling call the Anthropic API rejects on resume.
+    Rewind trims these off the tail so the truncated artifact stays resumable.
+    """
+    if line.get("type") != "assistant":
+        return False
+    msg = line.get("message")
+    if not isinstance(msg, dict):
+        return False
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return False
+    return any(
+        isinstance(b, dict) and b.get("type") == "tool_use" for b in content
+    )
+
+
+def _trim_resumable_tail(lines: list[dict[str, Any]]) -> tuple[int, int]:
+    """Trim the tail in place until it is a resumable boundary.
+
+    Pops, in a single pass to fixpoint: (a) trailing-noise user turns
+    (empty/interrupt/command scaffolding) and (b) a trailing assistant turn whose
+    content has an unanswered tool_use (dangling after truncation). Returns
+    (trimmed_trailing, trimmed_dangling_tool_use).
+
+    A user tail (pending_user_input) and an assistant text tail (clean) are both
+    valid resume boundaries, so neither is trimmed.
+    """
+    trimmed_trailing = 0
+    trimmed_dangling = 0
+    while lines:
+        if _is_trailing_noise(lines[-1]):
+            lines.pop()
+            trimmed_trailing += 1
+            continue
+        if _assistant_has_tool_use(lines[-1]):
+            lines.pop()
+            trimmed_dangling += 1
+            continue
+        break
+    return trimmed_trailing, trimmed_dangling
+
+
+def _ancestor_chain(
+    lines: list[dict[str, Any]], target_uuid: str
+) -> list[dict[str, Any]]:
+    """The root→target lineage: the target and every ancestor, oldest first.
+
+    Walks `parentUuid` links backward from the target to the root, so the kept
+    conversation is exactly the chain leading to the chosen turn — NOT a file-order
+    slice. A conversion artifact resumed interactively can grow into a TREE (a
+    message edit forks sibling branches); file-order slicing would splice abandoned
+    branches into the result, but the ancestor walk keeps only the real lineage.
+
+    A cycle (malformed transcript) or a missing parent link terminates the walk at
+    that point, treating the last reachable node as the root.
+    """
+    by_uuid: dict[str, dict[str, Any]] = {}
+    for d in lines:
+        u = d.get("uuid")
+        if u is not None:
+            by_uuid[u] = d  # last write wins; the target is guarded as unique upstream
+
+    chain: list[dict[str, Any]] = []
+    visited: set[str] = set()
+    current: Optional[dict[str, Any]] = by_uuid.get(target_uuid)
+    while current is not None:
+        uid = current.get("uuid")
+        if uid in visited:
+            break  # cycle guard
+        if uid is not None:
+            visited.add(uid)
+        chain.append(current)
+        parent_uuid = current.get("parentUuid")
+        current = by_uuid.get(parent_uuid) if parent_uuid else None
+    chain.reverse()
+    return chain
+
+
+@dataclass
+class RewindResult:
+    """The outcome of one in-place rewind."""
+
+    kind: str  # 'subagent' | 'session'
+    artifact_id: str
+    target_turn: str
+    cut: str  # 'after' | 'before'
+    turns_before: int
+    turns_after: int
+    removed_after_cut: int
+    trimmed_trailing: int
+    trimmed_dangling_tool_use: int
+    tail_state: str
+    models: dict[str, Any]
+    environment: dict[str, Any]
+    lineage: list[dict[str, str]]
+    written_path: Path
+
+
+def rewind_transcript(
+    *,
+    transcript_path: Path,
+    artifact_id: str,
+    kind: str,
+    turn: str,
+    cut: str = "after",
+) -> RewindResult:
+    """Truncate a conversion artifact in place at `turn`, discarding the rest.
+
+    `kind` is 'subagent' or 'session' (caller-supplied, for the result). `turn`
+    is a uuid or prefix of a body (user/assistant) line in this transcript. `cut`
+    is 'after' (keep through the named turn — it becomes the new tail) or 'before'
+    (discard the named turn and everything after — the turn is the first line
+    dropped). After the cut the tail is trimmed to a resumable boundary.
+
+    The caller MUST have verified the file carries a provenance line before
+    calling — this function re-reads it only to re-stamp `lines_at_creation`.
+
+    Raises ValueError on: a turn that matches no body line, an ambiguous prefix
+    (more than one distinct uuid), a target uuid that repeats in the transcript, a
+    missing provenance line, or a cut/trim that would leave the transcript empty.
+    """
+    if cut not in ("after", "before"):
+        raise ValueError(f"cut must be 'after' or 'before', got {cut!r}")
+
+    raw = _read_raw_lines(transcript_path)
+
+    # Structural prefix = everything before the first body line (session header
+    # lines + the provenance line). Preserved verbatim except for the re-stamp.
+    first_body_idx = next(
+        (i for i, d in enumerate(raw) if d.get("type") in _CONVO_TYPES), None
+    )
+    if first_body_idx is None:
+        raise ValueError("transcript has no user/assistant turns to rewind")
+    prefix = raw[:first_body_idx]
+
+    prov_idx = next(
+        (i for i, d in enumerate(prefix) if d.get("type") == _PROVENANCE_TYPE), None
+    )
+    if prov_idx is None:
+        raise ValueError(
+            "no x-converter-provenance line found — refusing to rewind a "
+            "non-conversion transcript"
+        )
+
+    body = _keep_convo_lines(raw)
+    turns_before = len(body)
+
+    # Resolve the target turn within the body by uuid or prefix.
+    matched = [
+        d for d in body if (u := d.get("uuid")) and (u == turn or u.startswith(turn))
+    ]
+    if not matched:
+        raise ValueError(f"turn {turn!r} not found in this transcript")
+    distinct = {d["uuid"] for d in matched}
+    if len(distinct) > 1:
+        raise ValueError(
+            f"turn prefix {turn!r} is ambiguous — it matches {len(distinct)} "
+            f"distinct turns in this transcript. Pass a longer id."
+        )
+    target_full = next(iter(distinct))
+    if sum(1 for d in body if d.get("uuid") == target_full) > 1:
+        raise ValueError(
+            f"turn {target_full[:8]} appears more than once in this transcript "
+            "(a resumed transcript can repeat a uuid) — cannot unambiguously rewind "
+            "to it. Pick a turn with a unique id."
+        )
+
+    # Keep the lineage leading to the target — its ancestor chain — not a file-order
+    # slice: a resumed artifact may contain abandoned edit-branch siblings, and only
+    # the chain from root to the target is the conversation we are rewinding to.
+    # cut='after' keeps through the target; cut='before' drops the target itself.
+    chain = _ancestor_chain(body, target_full)
+    kept = chain if cut == "after" else chain[:-1]
+    removed_after_cut = turns_before - len(kept)
+
+    trimmed_trailing, trimmed_dangling = _trim_resumable_tail(kept)
+
+    if not kept:
+        raise ValueError(
+            "rewind would discard the entire conversation — nothing remains after "
+            f"the cut={cut} at turn {target_full[:8]} and the resumable-tail trim. "
+            "Pick a later turn or cut='after'."
+        )
+
+    # The kept chain is already linear; relinearize normalizes parentUuid (first
+    # null, each pointing at its predecessor) and mints any missing uuid.
+    _relinearize(kept)
+
+    lineage = _prior_lineage(raw)
+
+    # Re-stamp lines_at_creation to the new physical line count so the growth
+    # guard stays coherent, and record the rewind for forensics.
+    new_total = len(prefix) + len(kept)
+    sentinel = prefix[prov_idx].get("x_converter")
+    if isinstance(sentinel, dict):
+        sentinel["lines_at_creation"] = new_total
+        sentinel["rewound_to"] = target_full
+        sentinel["rewound_at"] = _now_iso()
+
+    # Write atomically: a destructive in-place truncation must never leave the
+    # transcript half-written. Build the new file beside the original, then
+    # os.replace() it in one atomic swap; on ANY failure the original is untouched.
+    tmp_path = transcript_path.with_name(transcript_path.name + ".rewind-tmp")
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            for d in prefix:
+                f.write(json.dumps(d) + "\n")
+            for d in kept:
+                f.write(json.dumps(d) + "\n")
+        os.replace(tmp_path, transcript_path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+    return RewindResult(
+        kind=kind,
+        artifact_id=artifact_id,
+        target_turn=target_full,
+        cut=cut,
+        turns_before=turns_before,
+        turns_after=len(kept),
+        removed_after_cut=removed_after_cut,
+        trimmed_trailing=trimmed_trailing,
+        trimmed_dangling_tool_use=trimmed_dangling,
+        tail_state=_tail_state(kept),
+        models=_model_stats(kept),
+        environment=_environment(kept),
+        lineage=lineage,
+        written_path=transcript_path,
     )
 
 

--- a/project-mining/src/cc_explorer/mcp_server.py
+++ b/project-mining/src/cc_explorer/mcp_server.py
@@ -1,9 +1,10 @@
 """MCP server wrapping the cc_explorer library.
 
 Exposes Claude Code chat log exploration as MCP tools via FastMCP.
-Most tools are read-only and return typed Pydantic response models; the two
-conversion tools (convert_session, delete_conversions) write/delete transcript
-copies. FastMCP auto-generates output schemas from return type annotations.
+Most tools are read-only and return typed Pydantic response models; the
+conversion tools (convert_session, rewind_transcript, delete_conversions)
+write/mutate/delete transcript copies. FastMCP auto-generates output schemas from
+return type annotations.
 """
 
 import os
@@ -24,6 +25,7 @@ from .conversion import (
     existing_custom_titles,
     growth_exceeded,
     is_conversion_artifact,
+    rewind_transcript as rewind_transcript_file,
 )
 from .formatting import matches_id
 from .models import parse_hide
@@ -44,6 +46,7 @@ from .responses import (
     ProjectListResponse,
     ReadTurnResponse,
     RefusedDeletion,
+    RewindTranscriptResponse,
     SearchProjectsResponse,
     SessionAgentsResponse,
     SessionListResponse,
@@ -123,6 +126,16 @@ _CONVERT_ANNOTATIONS = {
 _DELETE_ANNOTATIONS = {
     "readOnlyHint": False,
     "destructiveHint": True,
+    "openWorldHint": False,
+}
+
+# rewind_transcript truncates a conversion artifact IN PLACE — the discarded tail
+# is gone, so it is destructive (and idempotent: re-running the same rewind on an
+# already-rewound file is a no-op once the tail is shorter than the cut point).
+_REWIND_ANNOTATIONS = {
+    "readOnlyHint": False,
+    "destructiveHint": True,
+    "idempotentHint": True,
     "openWorldHint": False,
 }
 
@@ -1326,6 +1339,75 @@ def _dest_project_dir(project_path: str) -> Path:
     from ._claude_paths import _canonicalize_path, _get_project_dir
 
     return _get_project_dir(_canonicalize_path(project_path))
+
+
+def _resolve_artifact_for_rewind(
+    src_id: str, src_project: str | None
+) -> tuple[str, str, Path]:
+    """Resolve a session-or-agent id to (kind, full_id, path) for rewind, or raise.
+
+    Accepts EITHER a session id or an agent id (you rewind whatever a convert
+    produced), scoped to `src_project` when given. Delegates to the shared
+    artifact resolver (the same one delete_conversions uses), which enforces the
+    _MIN_ID_LEN floor — an in-place mutation must not fire on a sloppy prefix —
+    and raises on an ambiguous prefix with the candidates listed.
+    """
+    proj_sel = [src_project] if src_project else None
+    sessions, _ = _load_all_sessions(proj_sel)
+    _, kind, full_id, path = _resolve_artifacts_corpus([src_id], sessions)[0]
+    if not kind or path is None:
+        raise ToolError(f"No session or subagent matching: {src_id}")
+    return (kind, full_id, path)
+
+
+@mcp.tool(annotations=_REWIND_ANNOTATIONS)
+def rewind_transcript(
+    src_id: Annotated[
+        str,
+        Field(description="The conversion artifact to rewind — a session id or an agent id (prefixes accepted, but must resolve uniquely and be at least 6 chars). Only artifacts created by convert_session can be rewound."),
+    ],
+    turn: Annotated[
+        str,
+        Field(description="Turn UUID (or prefix) to cut at — a user/assistant line in this transcript. Read it off browse_session / read_turn / grep_session run against the artifact."),
+    ],
+    cut: Annotated[
+        Literal["after", "before"],
+        Field(description="'after' (default): keep through the named turn — it becomes the new tail. 'before': discard the named turn and everything after it — use this to rewind to just before a user prompt so you can re-drive from there."),
+    ] = "after",
+    src_project: Annotated[
+        str | None,
+        Field(description="Optional single project (path or bare name) to scope source resolution. Default: search all projects."),
+    ] = None,
+) -> RewindTranscriptResponse:
+    """Truncate a converted transcript IN PLACE at a chosen turn, discarding everything after — so the artifact resumes from that earlier point.
+
+    For rewinding a converted session or subagent back to a known turn to replay it: re-run a skill from a fixed starting state, regenerate a different user prompt, or retry from before a branch you didn't like. The cut is in place and destructive — the discarded tail is gone (this is not a copy; use convert_session if you want to preserve the original).
+
+    ONLY conversion artifacts are eligible: the file must carry an x-converter-provenance line (the same "this is ours to mutate" trust surface delete_conversions keys off). A real session or normally-dispatched subagent is refused untouched — we never truncate a transcript we didn't write. Unlike delete_conversions, a converted SESSION is eligible (it is yours to replay), and there is no growth guard: rewinding a resumed/grown artifact is the whole point.
+
+    cut='after' keeps through the named turn; cut='before' drops the named turn onward (rewind to just before a user prompt to regenerate it). After the cut the tail is trimmed to a resumable boundary — trailing noise and any dangling assistant tool_use (which would otherwise break resume) are dropped and reported. The response leads with the artifact id and the exact `invocation` to resume it (SendMessage for a subagent, `claude -r` for a session); `lines_at_creation` is re-stamped so the artifact stays deletable by delete_conversions."""
+    _validate_turn_id(turn)
+    kind, full_id, path = _resolve_artifact_for_rewind(src_id, src_project)
+
+    if not is_conversion_artifact(path):
+        raise ToolError(
+            f"{kind} {full_id[:12]} is not a conversion artifact (no "
+            f"x-converter-provenance line) — refusing to rewind a transcript we "
+            f"didn't write. Convert it first with convert_session if you want a "
+            f"mutable copy."
+        )
+
+    try:
+        result = rewind_transcript_file(
+            transcript_path=path,
+            artifact_id=full_id,
+            kind=kind,
+            turn=turn,
+            cut=cut,
+        )
+    except ValueError as e:
+        raise ToolError(str(e))
+    return RewindTranscriptResponse.from_result(result)
 
 
 # Refusal reasons (kept as constants so the sweep and explicit-id paths share

--- a/project-mining/src/cc_explorer/responses.py
+++ b/project-mining/src/cc_explorer/responses.py
@@ -1024,6 +1024,63 @@ class ConvertSessionResponse(SparseModel):
 
 
 # =============================================================================
+# rewind_transcript
+# =============================================================================
+
+
+class RewindTranscriptResponse(SparseModel):
+    """Result of an in-place rewind of a conversion artifact.
+
+    Leads with what the artifact now is and the exact next step (`invocation`) to
+    resume it. The cut is IN PLACE and destructive — the discarded tail is gone.
+    Only conversion artifacts (carrying an x-converter-provenance line) are ever
+    rewound; a real session or subagent is refused untouched.
+    """
+
+    operation: str = Field(description="Always 'rewind' — the artifact was truncated in place.")
+    kind: str = Field(description="'subagent' or 'session'.")
+    artifact_id: str = Field(description="The agent id (subagent) or session uuid (session) that was rewound.")
+    invocation: str = Field(description="The exact next step to resume the rewound artifact.")
+    cut: str = Field(description="'after' (named turn kept as the new tail) or 'before' (named turn discarded).")
+    target_turn: str = Field(description="Full uuid of the turn the cut was made at.")
+    turns_before: int = Field(description="Body turns (user+assistant) before the rewind.")
+    turns_after: int = Field(description="Body turns remaining after the cut and resumable-tail trim.")
+    removed_after_cut: int = Field(description="Turns discarded by the cut itself (before tail trimming).")
+    trimmed_trailing: int = Field(description="Trailing-noise turns (empty/interrupt/command scaffolding) trimmed off the new tail.")
+    trimmed_dangling_tool_use: int = Field(description="Trailing assistant turns dropped because their tool_use had no following tool_result (would break resume).")
+    tail_state: str = Field(description="'clean' (ends on an assistant text turn) or 'pending_user_input' (ends on a user turn awaiting a reply).")
+    models: ConversionModels = Field(description="Assistant model history of the rewound transcript.")
+    environment: ConversionEnvironment = Field(description="Original cwd/branch/version/age, read off the kept turns.")
+    lineage: list[dict[str, str]] = Field(
+        description="Conversion chain carried by the artifact: each hop is {as: 'session'|'subagent', id: ...}, oldest first.",
+    )
+
+    @classmethod
+    def from_result(cls, r) -> "RewindTranscriptResponse":
+        if r.kind == "subagent":
+            invocation = f'SendMessage(to: "{r.artifact_id}")'
+        else:
+            invocation = f"claude -r {r.artifact_id}"
+        return cls(
+            operation="rewind",
+            kind=r.kind,
+            artifact_id=r.artifact_id,
+            invocation=invocation,
+            cut=r.cut,
+            target_turn=r.target_turn,
+            turns_before=r.turns_before,
+            turns_after=r.turns_after,
+            removed_after_cut=r.removed_after_cut,
+            trimmed_trailing=r.trimmed_trailing,
+            trimmed_dangling_tool_use=r.trimmed_dangling_tool_use,
+            tail_state=r.tail_state,
+            models=ConversionModels(**r.models),
+            environment=ConversionEnvironment(**r.environment),
+            lineage=r.lineage,
+        )
+
+
+# =============================================================================
 # delete_conversions
 # =============================================================================
 

--- a/project-mining/tests/test_conversion.py
+++ b/project-mining/tests/test_conversion.py
@@ -1151,3 +1151,302 @@ def test_nested_agents_excludes_conversion_artifacts(fake_claude):
     )
     # Conversion artifact is not counted as a nested agent.
     assert resp.nested_agents is None or resp.nested_agents == 0
+
+
+# =============================================================================
+# rewind_transcript
+# =============================================================================
+#
+# Rewind truncates a conversion artifact IN PLACE at a chosen turn. Turn ids
+# passed to the tool go through _validate_turn_id, so rewind fixtures use
+# all-hex uuids (the synthesized session builders above use 'u'/'a'-prefixed
+# ids that are fine on the wire but not valid turn args).
+
+# Hex body uuids (valid as `turn` args).
+RW_T1 = "aaaa0001-0000-0000-0000-000000000001"  # user
+RW_A1 = "aaaa0001-0000-0000-0000-000000000002"  # assistant
+RW_T2 = "aaaa0001-0000-0000-0000-000000000003"  # user
+RW_A2 = "aaaa0001-0000-0000-0000-000000000004"  # assistant
+
+
+def _rw_body(agent_id: str) -> list[dict]:
+    """A 4-turn subagent body (user/assistant x2) with hex uuids."""
+    return [
+        _user(RW_T1, "ONE", agentId=agent_id, isSidechain=True),
+        _assistant(RW_A1, "TWO", parent=RW_T1, agentId=agent_id, isSidechain=True),
+        _user(RW_T2, "THREE", parent=RW_A1, agentId=agent_id, isSidechain=True),
+        _assistant(RW_A2, "FOUR", parent=RW_T2, agentId=agent_id, isSidechain=True),
+    ]
+
+
+def _assistant_tool_use(uuid: str, tool: str, *, parent=None, agent_id=None) -> dict:
+    line = _assistant(uuid, "", parent=parent)
+    line["message"]["content"] = [{"type": "tool_use", "id": "toolu_x", "name": tool, "input": {}}]
+    if agent_id:
+        line["agentId"] = agent_id
+        line["isSidechain"] = True
+    return line
+
+
+def _user_tool_result(uuid: str, *, parent=None, agent_id=None) -> dict:
+    line = _user(uuid, "", parent=parent)
+    line["message"]["content"] = [{"type": "tool_result", "tool_use_id": "toolu_x", "content": "ok"}]
+    if agent_id:
+        line["agentId"] = agent_id
+        line["isSidechain"] = True
+    return line
+
+
+RW_AGENT = "a" + "7" * 16
+
+
+def _lay_rw_subagent(fake_claude, agent_id=RW_AGENT, *, body=None, conv=True) -> Path:
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    return _lay_down_subagent(
+        fake_claude, agent_id, is_conversion_artifact=conv,
+        lines=body if body is not None else _rw_body(agent_id),
+    )
+
+
+def test_rewind_subagent_cut_after(fake_claude):
+    path = _lay_rw_subagent(fake_claude)
+
+    resp = srv.rewind_transcript(src_id=RW_AGENT, turn=RW_A1, cut="after")
+
+    assert resp.operation == "rewind"
+    assert resp.kind == "subagent"
+    assert resp.artifact_id == RW_AGENT
+    assert resp.invocation == f'SendMessage(to: "{RW_AGENT}")'
+    assert resp.cut == "after"
+    assert resp.target_turn == RW_A1
+    assert resp.turns_before == 4
+    assert resp.turns_after == 2  # ONE, TWO
+    assert resp.removed_after_cut == 2
+    assert resp.tail_state == "clean"  # ends on assistant TWO
+
+    body = _convo_only(_read_jsonl(path))
+    assert _convo_texts(body) == ["ONE", "TWO"]
+
+
+def test_rewind_subagent_cut_before(fake_claude):
+    """cut='before' a user prompt → the prompt and everything after is gone."""
+    path = _lay_rw_subagent(fake_claude)
+
+    resp = srv.rewind_transcript(src_id=RW_AGENT, turn=RW_T2, cut="before")
+
+    assert resp.cut == "before"
+    assert resp.turns_after == 2  # ONE, TWO — the THREE prompt is dropped
+    assert resp.tail_state == "clean"
+    body = _convo_only(_read_jsonl(path))
+    assert _convo_texts(body) == ["ONE", "TWO"]
+
+
+def test_rewind_restamps_lines_at_creation_and_marks_rewound(fake_claude):
+    path = _lay_rw_subagent(fake_claude)
+    srv.rewind_transcript(src_id=RW_AGENT, turn=RW_A1, cut="after")
+
+    lines = _read_jsonl(path)
+    prov = _provenance_lines(lines)[0]["x_converter"]
+    # File is provenance line + 2 kept body lines == 3.
+    assert prov["lines_at_creation"] == len(lines) == 3
+    assert prov["rewound_to"] == RW_A1
+    assert "rewound_at" in prov
+
+
+def test_rewind_keeps_artifact_deletable(fake_claude):
+    """After a rewind the re-stamp keeps the growth guard satisfied → still deletable."""
+    from cc_explorer.conversion import growth_exceeded, is_conversion_artifact as _is_conv
+
+    path = _lay_rw_subagent(fake_claude)
+    srv.rewind_transcript(src_id=RW_AGENT, turn=RW_A1, cut="after")
+    assert _is_conv(path)
+    assert not growth_exceeded(path)
+
+    resp = srv.delete_conversions(ids=[RW_AGENT])
+    assert len(resp.deleted) == 1 and not resp.refused
+    assert not path.exists()
+
+
+def test_rewind_trims_dangling_tool_use(fake_claude):
+    """Cutting at an assistant tool_use turn trims it off so resume stays valid."""
+    body = [
+        _user(RW_T1, "ONE", agentId=RW_AGENT, isSidechain=True),
+        _assistant_tool_use(RW_A1, "Bash", parent=RW_T1, agent_id=RW_AGENT),
+        _user_tool_result(RW_T2, parent=RW_A1, agent_id=RW_AGENT),
+        _assistant(RW_A2, "DONE", parent=RW_T2, agentId=RW_AGENT, isSidechain=True),
+    ]
+    path = _lay_rw_subagent(fake_claude, body=body)
+
+    resp = srv.rewind_transcript(src_id=RW_AGENT, turn=RW_A1, cut="after")
+    # The cut keeps ONE + the tool_use assistant; the dangling assistant is trimmed.
+    assert resp.trimmed_dangling_tool_use == 1
+    assert resp.turns_after == 1  # just ONE
+    assert resp.tail_state == "pending_user_input"
+    body_out = _convo_only(_read_jsonl(path))
+    assert _convo_texts(body_out) == ["ONE"]
+
+
+def test_rewind_trims_trailing_noise(fake_claude):
+    body = _rw_body(RW_AGENT) + [
+        _user("aaaa0001-0000-0000-0000-000000000099", "[Request interrupted by user]",
+              parent=RW_A2, agentId=RW_AGENT, isSidechain=True),
+    ]
+    path = _lay_rw_subagent(fake_claude, body=body)
+    # Cut after the interrupt line → it should be trimmed as trailing noise.
+    resp = srv.rewind_transcript(src_id=RW_AGENT, turn="aaaa0001-0000-0000-0000-000000000099", cut="after")
+    assert resp.trimmed_trailing == 1
+    assert resp.turns_after == 4
+    assert resp.tail_state == "clean"
+
+
+def test_rewind_refuses_non_conversion_subagent(fake_claude):
+    """An untagged subagent (no provenance line) is refused untouched."""
+    path = _lay_rw_subagent(fake_claude, conv=False)
+    before = path.read_text()
+
+    with pytest.raises(ToolError) as exc:
+        srv.rewind_transcript(src_id=RW_AGENT, turn=RW_A1, cut="after")
+    assert "not a conversion artifact" in str(exc.value)
+    assert path.read_text() == before  # untouched
+
+
+def test_rewind_refuses_real_session(fake_claude):
+    """A real, untagged session is refused — we never truncate what we didn't write."""
+    fake_claude.write_session(SID_A, _simple_session_lines())
+    sess_path = fake_claude.project_dir(PROJECT) / f"{SID_A}.jsonl"
+    before = sess_path.read_text()
+
+    with pytest.raises(ToolError) as exc:
+        srv.rewind_transcript(src_id=SID_A, turn="a1111111-0000-0000-0000-000000000002", cut="after")
+    assert "not a conversion artifact" in str(exc.value)
+    assert sess_path.read_text() == before
+
+
+def test_rewind_allows_converted_session(fake_claude):
+    """Unlike delete_conversions, a CONVERTED session is eligible for rewind."""
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    _lay_down_subagent(fake_claude, AGENT_ID, is_conversion_artifact=True, lines=_rw_body(AGENT_ID))
+    r = srv.convert_session(direction="subagent_to_session", src_id=AGENT_ID, src_project=PROJECT)
+    out_path = fake_claude.project_dir(PROJECT) / f"{r.created_id}.jsonl"
+    from cc_explorer.conversion import is_conversion_artifact as _is_conv
+    assert _is_conv(out_path)
+
+    resp = srv.rewind_transcript(src_id=r.created_id, turn=RW_A1, cut="after")
+    assert resp.kind == "session"
+    assert resp.invocation == f"claude -r {r.created_id}"
+    assert resp.turns_after == 2
+    # The session header (mode/permission-mode/custom-title) survives the rewrite.
+    lines = _read_jsonl(out_path)
+    assert lines[0]["type"] == "mode"
+    assert any(l.get("type") == "custom-title" for l in lines[:4])
+    assert _provenance_lines(lines)  # provenance preserved
+
+
+def test_rewind_turn_not_found(fake_claude):
+    _lay_rw_subagent(fake_claude)
+    with pytest.raises(ToolError) as exc:
+        srv.rewind_transcript(src_id=RW_AGENT, turn="deadbeef-0000-0000-0000-000000000000", cut="after")
+    assert "not found" in str(exc.value)
+
+
+def test_rewind_cut_before_first_turn_refused(fake_claude):
+    """cut='before' the first turn would empty the transcript → refused."""
+    path = _lay_rw_subagent(fake_claude)
+    before = path.read_text()
+    with pytest.raises(ToolError) as exc:
+        srv.rewind_transcript(src_id=RW_AGENT, turn=RW_T1, cut="before")
+    assert "discard the entire conversation" in str(exc.value)
+    assert path.read_text() == before  # untouched on refusal
+
+
+def test_rewind_short_id_rejected(fake_claude):
+    _lay_rw_subagent(fake_claude)
+    with pytest.raises(ToolError) as exc:
+        srv.rewind_transcript(src_id="ab", turn=RW_A1, cut="after")
+    assert "too short" in str(exc.value)
+
+
+def test_rewind_relinearizes_kept_body(fake_claude):
+    path = _lay_rw_subagent(fake_claude)
+    srv.rewind_transcript(src_id=RW_AGENT, turn=RW_T2, cut="after")
+    body = _convo_only(_read_jsonl(path))
+    assert body[0]["parentUuid"] is None
+    for prev, cur in zip(body, body[1:]):
+        assert cur["parentUuid"] == prev["uuid"]
+
+
+def test_rewind_follows_active_thread_not_file_order(fake_claude):
+    """A resumed artifact with an abandoned edit-branch sibling: rewind keeps the
+    target's ancestor lineage, never file-order siblings."""
+    # ONE -> TWO(assistant). Then the user 'edited' TWO's follow-up: an abandoned
+    # branch THREE-OLD and the live branch THREE-NEW, both children of TWO. We
+    # rewind to FOUR, which descends from THREE-NEW. THREE-OLD must NOT appear.
+    THREE_OLD = "aaaa0001-0000-0000-0000-0000000000a1"
+    THREE_NEW = "aaaa0001-0000-0000-0000-0000000000a2"
+    FOUR = "aaaa0001-0000-0000-0000-0000000000a3"
+    body = [
+        _user(RW_T1, "ONE", agentId=RW_AGENT, isSidechain=True),
+        _assistant(RW_A1, "TWO", parent=RW_T1, agentId=RW_AGENT, isSidechain=True),
+        _user(THREE_OLD, "THREE-OLD", parent=RW_A1, agentId=RW_AGENT, isSidechain=True),
+        _user(THREE_NEW, "THREE-NEW", parent=RW_A1, agentId=RW_AGENT, isSidechain=True),
+        _assistant(FOUR, "FOUR", parent=THREE_NEW, agentId=RW_AGENT, isSidechain=True),
+    ]
+    path = _lay_rw_subagent(fake_claude, body=body)
+
+    resp = srv.rewind_transcript(src_id=RW_AGENT, turn=FOUR, cut="after")
+    texts = _convo_texts(_convo_only(_read_jsonl(path)))
+    assert texts == ["ONE", "TWO", "THREE-NEW", "FOUR"]  # THREE-OLD dropped
+    assert "THREE-OLD" not in texts
+    assert resp.turns_after == 4
+    # The 5 body turns minus the 4 kept = 1 removed (the abandoned sibling).
+    assert resp.removed_after_cut == 1
+
+
+def test_rewind_duplicate_target_uuid_refused(fake_claude):
+    """If the target uuid repeats in the transcript, rewind refuses rather than
+    silently truncating at the first occurrence."""
+    dup = RW_A1
+    body = [
+        _user(RW_T1, "ONE", agentId=RW_AGENT, isSidechain=True),
+        _assistant(dup, "TWO", parent=RW_T1, agentId=RW_AGENT, isSidechain=True),
+        _user(RW_T2, "THREE", parent=dup, agentId=RW_AGENT, isSidechain=True),
+        _assistant(dup, "FOUR", parent=RW_T2, agentId=RW_AGENT, isSidechain=True),  # same uuid
+    ]
+    path = _lay_rw_subagent(fake_claude, body=body)
+    before = path.read_text()
+    with pytest.raises(ToolError) as exc:
+        srv.rewind_transcript(src_id=RW_AGENT, turn=dup, cut="after")
+    assert "more than once" in str(exc.value)
+    assert path.read_text() == before  # untouched
+
+
+def test_rewind_atomic_no_tempfile_left_behind(fake_claude):
+    """A successful rewind leaves no .rewind-tmp sidecar."""
+    path = _lay_rw_subagent(fake_claude)
+    srv.rewind_transcript(src_id=RW_AGENT, turn=RW_A1, cut="after")
+    tmp = path.with_name(path.name + ".rewind-tmp")
+    assert not tmp.exists()
+    assert path.exists()
+
+
+def test_rewind_atomic_write_preserves_original_on_failure(fake_claude, monkeypatch):
+    """If the write fails mid-way, the original transcript is left intact (the
+    atomic temp+replace guarantees no half-written file)."""
+    import cc_explorer.conversion as conv
+
+    path = _lay_rw_subagent(fake_claude)
+    before = path.read_text()
+
+    real_replace = conv.os.replace
+
+    def boom(src, dst):
+        raise OSError("simulated disk failure")
+
+    monkeypatch.setattr(conv.os, "replace", boom)
+    with pytest.raises(OSError):
+        srv.rewind_transcript(src_id=RW_AGENT, turn=RW_A1, cut="after")
+
+    # Original untouched, temp cleaned up.
+    assert path.read_text() == before
+    assert not path.with_name(path.name + ".rewind-tmp").exists()
+    monkeypatch.setattr(conv.os, "replace", real_replace)

--- a/project-mining/uv.lock
+++ b/project-mining/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "cc-explorer"
-version = "1.35.0"
+version = "1.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What

Adds an MCP tool `rewind_transcript` to cc-explorer. It rewinds a converted session or subagent back to a chosen turn — truncating the transcript **in place** so it can be replayed from a fixed starting state (re-run a skill, regenerate a different user prompt, retry from before a branch you didn't like).

## Why

Testing skills against a past conversation needs a known, repeatable starting point. After resuming a converted artifact you can rewind it to a turn and drive it again. The `cut="before"` mode rewinds to just *before* a user prompt so a fresh prompt can be generated in its place.

## Design

- **Gated on provenance.** Only files carrying the `x-converter-provenance` line — the same "this is ours to mutate" trust surface `delete_conversions` keys off — are eligible. A real session or dispatched subagent is refused untouched. Unlike `delete_conversions`, a converted **session** is eligible (it's yours to replay) and there is no growth guard (rewinding a resumed/grown artifact is the whole point).
- **Cut semantics.** `cut="after"` (default) keeps through the named turn; `cut="before"` drops the named turn onward.
- **Ancestor-lineage, not file-order.** The kept conversation is the target's `parentUuid` ancestor chain, so a resumed/edited artifact that forked into a tree keeps only the real chain to the chosen turn (abandoned edit-branch siblings are dropped).
- **Resumable-tail trim.** Trailing noise and any dangling assistant `tool_use` (no following `tool_result`) are dropped and reported, so the truncated file still resumes.
- **Atomic write.** Temp file + `os.replace` — any failure leaves the original transcript intact. `lines_at_creation` is re-stamped so the artifact stays deletable.
- `_resolve_artifact_for_rewind` delegates to the shared `_resolve_artifacts_corpus` resolver instead of re-implementing session/agent prefix matching.

## Review

Ran the project's multi-angle `/code-review high`. Fixed: non-atomic write (blocking), file-order slicing corrupting tree artifacts (switched to ancestor-walk), duplicate-uuid silent truncation (now refused), resolver duplication (delegated). Refuted: orphan-`tool_result`-after-trim (only arises from malformed input that can't occur in a real chain).

## Tests

340 passing, including 17 new rewind cases: cut after/before, dangling-tool_use trim, trailing-noise trim, provenance gate (refuses real session/untaged subagent), converted-session eligibility, ancestor-thread correctness on a forked artifact, duplicate-uuid refusal, atomic-write preservation on failure, re-stamp keeping the artifact deletable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)