### PR TITLE
fix(cc-explorer): rewind resolves artifacts by filename, not full-corpus parse

### DIFF
--- a/project-mining/.claude-plugin/plugin.json
+++ b/project-mining/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-mining",
-  "version": "2.46.2",
+  "version": "2.46.3",
   "description": "Mine project histories for behavioral evidence. Search chat logs, git history, docs, and code for concrete examples of specific patterns, values, or skills.",
   "author": {
     "name": "Cory King",

--- a/project-mining/pyproject.toml
+++ b/project-mining/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-explorer"
-version = "1.38.0"
+version = "1.38.1"
 description = "MCP server for exploring Claude Code chat history — search conversations, quote moments, inspect subagents."
 requires-python = ">=3.11"
 dependencies = [

--- a/project-mining/src/cc_explorer/mcp_server.py
+++ b/project-mining/src/cc_explorer/mcp_server.py
@@ -13,6 +13,7 @@ import re
 import sys
 import traceback
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, Literal, Optional
@@ -366,6 +367,94 @@ def _projects_for_sessions(
         if any(sid == w for sid in refs for w in wanted):
             matched.append(proj)
     return matched
+
+
+def _narrow_projects_for_artifacts(
+    ids: list[str], projects: list[str] | None
+) -> list[str]:
+    """Cheaply find the project(s) holding the given session/agent ids.
+
+    The artifact resolvers (rewind, agent-direction convert, delete-by-id) need
+    `SessionInfo` objects, but `_load_all_sessions` PARSES every transcript in
+    every selected project — on a large corpus that is a ~minute-long full-corpus
+    read which blows the MCP request timeout (the connection drops mid-call, yet
+    a destructive op like rewind has already mutated the file: it looks like the
+    tool destroyed the artifact). Resolution only needs file paths and ids, so we
+    narrow the project set FIRST, by filename discovery alone — `load_conversations`
+    never opens a transcript:
+
+      - a SESSION id matches a ``<id>.jsonl`` transcript filename;
+      - an AGENT id matches a ``<session>/subagents/**/agent-<id>.jsonl`` filename
+        (a pure filesystem glob; agent files are ``agent-a…`` so a session uuid
+        never collides with one). The ``**`` matches agents both directly under
+        ``subagents/`` AND workflow-nested under ``subagents/workflows/<runId>/``
+        — the same tree `collect_agent_files` recurses, so resolution can't miss a
+        workflow-dispatched subagent.
+
+    Returns the project paths to load, in `resolve_projects` order. When `projects`
+    is given it is used verbatim (already scoped — no narrowing needed). Empty when
+    no id matches by name anywhere: the caller raises its own "no match" error
+    rather than re-expanding to a full-corpus parse.
+    """
+    if projects:
+        return resolve_projects(projects)
+
+    wanted = [PrefixId(i) for i in ids]
+    all_projects = resolve_projects(None)
+    matched: set[str] = set()
+    for proj in all_projects:
+        refs = load_conversations(proj)
+        # Session-id hit: a transcript filename matches.
+        if any(sid == w for sid in refs for w in wanted):
+            matched.add(proj)
+            continue
+        # Agent-id hit: a subagent filename matches under any session dir. Pure
+        # filesystem glob — never opens a transcript.
+        enc_dirs = {ref.path.parent for ref in refs.values()}
+        if any(
+            next(enc.glob(f"*/subagents/**/agent-{i}*.jsonl"), None) is not None
+            for enc in enc_dirs
+            for i in ids
+        ):
+            matched.add(proj)
+    return [p for p in all_projects if p in matched]
+
+
+@dataclass(frozen=True)
+class _ArtifactSession:
+    """A session located by FILENAME only — no transcript parse.
+
+    `_resolve_artifacts_corpus` reads only `.session_id`, `.path`, and
+    `.project_path`, so resolving an id to its artifact never needs the full
+    `SessionInfo` (which costs a parse of every transcript in the project). This
+    carries exactly those three, built from `load_conversations` (filename
+    discovery), so resolution stays sub-second even in an artifact-heavy project.
+    """
+
+    session_id: PrefixId
+    path: Path
+    project_path: str
+
+
+def _sessions_by_filename(projects: list[str]) -> list[_ArtifactSession]:
+    """Every session in `projects`, discovered by filename — NO transcript parse.
+
+    The cheap corpus for artifact resolution (rewind, agent-direction convert,
+    delete-by-id): `load_conversations` lists `<id>.jsonl` files (worktrees
+    pooled) without opening any of them, where `_load_all_sessions` would parse
+    each one. De-duplicated by full session id across the given projects.
+    """
+    out: list[_ArtifactSession] = []
+    seen: set[str] = set()
+    for proj in projects:
+        for sid, ref in load_conversations(proj).items():
+            if sid.full in seen:
+                continue
+            seen.add(sid.full)
+            out.append(
+                _ArtifactSession(session_id=sid, path=ref.path, project_path=proj)
+            )
+    return out
 
 
 def _resolve_unique_session(
@@ -1324,11 +1413,18 @@ def _resolve_agent_for_convert(src_id: str, src_project: str | None):
     Walks every session's subagents dir across the selected projects. A prefix
     matching agent files in more than one distinct full id raises with the
     holding sessions listed, mirroring session-prefix ambiguity handling.
+
+    Narrows to the holding project by filename FIRST, then resolves over a
+    filename-only corpus (`_sessions_by_filename`), so an unscoped resolve never
+    parses a transcript — the same full-corpus-parse hazard rewind hit.
     """
     proj_sel = [src_project] if src_project else None
-    sessions, _ = _load_all_sessions(proj_sel)
+    narrowed = _narrow_projects_for_artifacts([src_id], proj_sel)
+    if not narrowed:
+        raise ToolError(f"No subagent matching: {src_id}")
+    sessions = _sessions_by_filename(narrowed)
 
-    matches: list[tuple] = []  # (AgentFile, SessionInfo)
+    matches: list[tuple] = []  # (AgentFile, _ArtifactSession)
     for s in sessions:
         for af in collect_agent_files(resolve_subagents_dir(s.path)):
             if af.agent_id and PrefixId(af.agent_id) == src_id:
@@ -1507,9 +1603,19 @@ def _resolve_artifact_for_rewind(
     artifact resolver (the same one delete_conversions uses), which enforces the
     _MIN_ID_LEN floor — an in-place mutation must not fire on a sloppy prefix —
     and raises on an ambiguous prefix with the candidates listed.
+
+    Narrows to the holding project by filename FIRST, then resolves over a
+    filename-only corpus (`_sessions_by_filename`): parsing every transcript just
+    to resolve one id is a full-corpus read that times out the MCP call
+    mid-mutation (and even one busy project's parse is multi-second).
     """
     proj_sel = [src_project] if src_project else None
-    sessions, _ = _load_all_sessions(proj_sel)
+    narrowed = _narrow_projects_for_artifacts([src_id], proj_sel)
+    # Resolve over a filename-only corpus — no transcript parse. Empty narrowed
+    # (id matches no filename) still flows through the corpus resolver with no
+    # sessions, so it remains the single authority for both the _MIN_ID_LEN "too
+    # short" guard and the no-match message.
+    sessions = _sessions_by_filename(narrowed)
     _, kind, full_id, path = _resolve_artifacts_corpus([src_id], sessions)[0]
     if not kind or path is None:
         raise ToolError(f"No session or subagent matching: {src_id}")
@@ -1628,8 +1734,13 @@ def delete_conversions(
             )
         return DeleteConversionsResponse(deleted=deleted, refused=refused)
 
-    # Load corpus once for all ids.
-    all_sessions, _ = _load_all_sessions(None)
+    # Resolve all ids over a filename-only corpus, narrowed to the holding
+    # project(s) by filename first, so an unscoped delete never parses a
+    # transcript (the full-corpus-parse hazard rewind hit). Ids that match
+    # nothing by name fall through to _resolve_artifacts_corpus as no-match
+    # placeholders and are refused per-id below.
+    narrowed = _narrow_projects_for_artifacts(ids, None)
+    all_sessions = _sessions_by_filename(narrowed)
     resolved = _resolve_artifacts_corpus(ids, all_sessions)
 
     for raw_id, kind, full_id, path in resolved:

--- a/project-mining/tests/test_conversion.py
+++ b/project-mining/tests/test_conversion.py
@@ -1439,6 +1439,55 @@ def test_rewind_atomic_no_tempfile_left_behind(fake_claude):
     assert path.exists()
 
 
+def test_rewind_resolves_without_parsing_transcripts(fake_claude, monkeypatch):
+    """Regression: rewind resolves its artifact by FILENAME alone — it must never
+    call _load_all_sessions (which parses every transcript in the project).
+
+    That parse reads every transcript in every selected project — on a real corpus
+    a multi-second-to-minute op that blew the MCP request timeout mid-call. Because
+    rewind mutates in place, the connection dropped AFTER the file was already
+    truncated, so the artifact looked destroyed (field-observed). Resolving an
+    AGENT id must still succeed via the subagent-filename glob, never by parsing."""
+    path = _lay_rw_subagent(fake_claude)
+
+    def boom(*a, **kw):  # any parse during resolution is the bug
+        raise AssertionError(
+            "rewind resolved via _load_all_sessions (full transcript parse) — it "
+            "must resolve by filename only (_sessions_by_filename)"
+        )
+
+    monkeypatch.setattr(srv, "_load_all_sessions", boom)
+    resp = srv.rewind_transcript(src_id=RW_AGENT, turn=RW_A1, cut="after")
+
+    assert resp.artifact_id == RW_AGENT  # agent id resolved by filename glob
+    assert _convo_texts(_convo_only(_read_jsonl(path))) == ["ONE", "TWO"]
+
+
+def test_narrow_finds_workflow_nested_agent(fake_claude):
+    """The agent-id narrowing glob must reach workflow-nested agents at
+    `<session>/subagents/workflows/<runId>/agent-<id>.jsonl`, not only direct
+    children of `subagents/`.
+
+    `collect_agent_files` recurses into `workflows/<runId>/`, so resolution
+    (used by subagent_to_session convert) must too — a shallow `subagents/agent-*`
+    glob would return [] and falsely report 'No subagent matching' for any
+    workflow-dispatched subagent."""
+    fake_claude.write_session(SID_PARENT, _simple_session_lines())
+    nested_id = "a" + "9" * 16
+    wf_dir = (
+        fake_claude.project_dir(PROJECT) / SID_PARENT / "subagents"
+        / "workflows" / "wf_testrun"
+    )
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    _write_jsonl(
+        wf_dir / f"agent-{nested_id}.jsonl",
+        [_user("u-wf-0000-0000-0000-00000000wf01", "X", agentId=nested_id, isSidechain=True)],
+    )
+
+    narrowed = srv._narrow_projects_for_artifacts([nested_id], None)
+    assert narrowed, "narrowing must find the project holding a workflow-nested agent"
+
+
 def test_rewind_atomic_write_preserves_original_on_failure(fake_claude, monkeypatch):
     """If the write fails mid-way, the original transcript is left intact (the
     atomic temp+replace guarantees no half-written file)."""

--- a/project-mining/uv.lock
+++ b/project-mining/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "cc-explorer"
-version = "1.38.0"
+version = "1.38.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## The bug (field-observed)

`rewind_transcript` looked like it **destroyed** its target. The sequence a real session hit:

| # | call | result |
|---|------|--------|
| 1 | `rewind_transcript(agent, turn, cut=before)` | ❌ `-32000: Connection closed` |
| 2 | same (retry) | ❌ `turn '…' not found in this transcript` |
| 3 | `browse_session(agent)` | ❌ `No session matching` |

## Root cause

The rewind **completed on disk** — the artifact's own `x-converter-provenance` line was re-stamped with `rewound_to`/`rewound_at` and the new line count. The connection died *after* the mutation.

`_resolve_artifact_for_rewind` called `_load_all_sessions(None)`, which **parses every transcript in every project** just to map one id → path. On the live corpus:

```
_load_all_sessions(None):        53.9s   (1166 sessions, all 19 projects)  ← rewind did this
_narrow + _sessions_by_filename:  1.0s                                      ← this PR
```

54s blows past the MCP request timeout → the client reports `Connection closed`. But rewind mutates **in place**, so the file was already truncated when the client gave up — hence "destroyed". `_resolve_agent_for_convert` and `delete_conversions`' by-id path shared the identical latent flaw.

## Fix

Resolution only needs each session's `id`, `path`, and `project` — all available **by filename** via `load_conversations`, with no parse. So:

1. `_narrow_projects_for_artifacts` — find the holding project(s) by filename (`<id>.jsonl` for sessions; `subagents/**/agent-<id>.jsonl` glob for agents). The `**` reaches workflow-nested subagents, the same tree `collect_agent_files` recurses.
2. `_ArtifactSession` / `_sessions_by_filename` — a filename-only corpus carrying exactly the three fields the resolver reads, replacing the parse-everything `_load_all_sessions`.

All three resolvers (rewind, agent-direction convert, delete-by-id) route through this. **Exact field-failure call: 54s → 1.0s.**

## Tests

- `test_rewind_resolves_without_parsing_transcripts` — rewind succeeds with `_load_all_sessions` patched to raise (proves filename-only resolution).
- `test_narrow_finds_workflow_nested_agent` — narrowing reaches `subagents/workflows/<runId>/agent-<id>.jsonl` (fails with a shallow glob, passes with `**`).
- Full suite: 351 passed.

## Out of scope

A pre-existing `PrefixId` double-wrap (collapses a full id to 8 chars in the session resolvers) surfaced during review — filed as #43. Behavior is identical for the old `SessionInfo` and the new `_ArtifactSession`, so it predates this change; kept out to stay focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)