### PR TITLE
fix(cc-explorer): clear "already rewound" message + browse_session accepts artifact ids

### DIFF
--- a/project-mining/.claude-plugin/plugin.json
+++ b/project-mining/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-mining",
-  "version": "2.46.3",
+  "version": "2.46.4",
   "description": "Mine project histories for behavioral evidence. Search chat logs, git history, docs, and code for concrete examples of specific patterns, values, or skills.",
   "author": {
     "name": "Cory King",

--- a/project-mining/pyproject.toml
+++ b/project-mining/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-explorer"
-version = "1.38.1"
+version = "1.38.2"
 description = "MCP server for exploring Claude Code chat history — search conversations, quote moments, inspect subagents."
 requires-python = ">=3.11"
 dependencies = [

--- a/project-mining/src/cc_explorer/conversion.py
+++ b/project-mining/src/cc_explorer/conversion.py
@@ -929,9 +929,12 @@ def rewind_transcript(
     The caller MUST have verified the file carries a provenance line before
     calling — this function re-reads it only to re-stamp `lines_at_creation`.
 
-    Raises ValueError on: a turn that matches no body line, an ambiguous prefix
-    (more than one distinct uuid), a target uuid that repeats in the transcript, a
-    missing provenance line, or a cut/trim that would leave the transcript empty.
+    Raises ValueError on: a turn that matches no body line (with a distinct
+    "already rewound" message when the requested turn is the one a PRIOR rewind
+    already cut — recorded in the provenance `rewound_to`/`rewound_at`), an
+    ambiguous prefix (more than one distinct uuid), a target uuid that repeats in
+    the transcript, a missing provenance line, or a cut/trim that would leave the
+    transcript empty.
     """
     if cut not in ("after", "before"):
         raise ValueError(f"cut must be 'after' or 'before', got {cut!r}")
@@ -964,6 +967,29 @@ def rewind_transcript(
         d for d in body if (u := d.get("uuid")) and (u == turn or u.startswith(turn))
     ]
     if not matched:
+        # The turn matches nothing — but distinguish the common "already rewound"
+        # case from a genuinely unknown turn. A prior cut='before' rewind CONSUMES
+        # its target (the named turn is the first line dropped), so retrying the
+        # SAME rewind now finds no matching line and would otherwise read as a
+        # cryptic "not found / tool broke". The provenance sentinel records that
+        # cut: `rewound_to` is the turn a prior rewind already ate, `rewound_at`
+        # when. When the requested turn IS that already-consumed turn (equal or a
+        # prefix of it), say so plainly — the cut already happened, the artifact is
+        # ready to resume from its current tail, and there is nothing to do.
+        prov = read_provenance(transcript_path)
+        rewound_to = prov.get("rewound_to") if isinstance(prov, dict) else None
+        if isinstance(rewound_to, str) and (
+            rewound_to == turn or rewound_to.startswith(turn)
+        ):
+            rewound_at = prov.get("rewound_at") if isinstance(prov, dict) else None
+            when = f" at {rewound_at}" if isinstance(rewound_at, str) else ""
+            raise ValueError(
+                f"turn {turn!r} is gone — this artifact was already rewound to "
+                f"{rewound_to}{when}, which CUT that turn (and everything after). "
+                "The rewind already succeeded; the artifact is ready to resume from "
+                "its current tail. Nothing to do — re-running the same rewind is a "
+                "no-op."
+            )
         raise ValueError(f"turn {turn!r} not found in this transcript")
     distinct = {d["uuid"] for d in matched}
     if len(distinct) > 1:

--- a/project-mining/src/cc_explorer/mcp_server.py
+++ b/project-mining/src/cc_explorer/mcp_server.py
@@ -457,6 +457,66 @@ def _sessions_by_filename(projects: list[str]) -> list[_ArtifactSession]:
     return out
 
 
+def _resolve_browsable_artifact(session: str, projects: list[str] | None) -> SessionInfo | None:
+    """Resolve a session/agent id to a browsable SessionInfo, agent-aware.
+
+    `browse_session` resolves real SESSIONS via `_resolve_unique_session`, but a
+    convert_session artifact is often a SUBAGENT whose id names no session file —
+    and rewind_transcript points users at browse_session to read the cut turn off
+    the artifact. So when the id isn't a session we fall through to here: the same
+    filename-only resolver rewind/delete use (`_narrow_projects_for_artifacts` +
+    `_sessions_by_filename` + `_resolve_artifacts_corpus`, NO transcript parse),
+    which resolves the id to a subagent transcript path. We wrap that path in a
+    minimal SessionInfo — `browse_session_turns` reads only `.path`, and the
+    response surfaces `.session_id` / `.project_path` — so the agent transcript
+    browses exactly like a session. Returns None when the id resolves to no
+    subagent (the caller keeps the original "no session matching" error).
+    """
+    narrowed = _narrow_projects_for_artifacts([session], projects)
+    sessions = _sessions_by_filename(narrowed)
+    _, kind, full_id, path = _resolve_artifacts_corpus([session], sessions)[0]
+    if kind != "subagent" or path is None:
+        return None
+    # The artifact's holding project: the parent session whose dir is an ancestor
+    # of the agent transcript path (agents live under <session>/subagents/...).
+    project_path = next(
+        (s.project_path for s in sessions if s.path.parent in path.parents),
+        narrowed[0] if narrowed else None,
+    )
+    return SessionInfo(
+        session_id=PrefixId(full_id),
+        path=path,
+        title=f"subagent {full_id[:8]}",
+        first_timestamp=None,
+        message_count=0,
+        project_path=project_path,
+    )
+
+
+def _resolve_unique_session_or_none(
+    all_sessions: list[SessionInfo], session: str
+) -> SessionInfo | None:
+    """Resolve a session id/prefix to one SessionInfo, None on no match.
+
+    Like `_resolve_unique_session` but returns None instead of raising when
+    nothing matches — for callers (browse_session) that fall through to a
+    different resolution path (an agent/artifact id) when the id is no session.
+    Ambiguity is still a hard error: a colliding prefix must be disambiguated, not
+    silently re-routed to the agent resolver.
+    """
+    matches = [s for s in all_sessions if PrefixId(s.session_id) == session]
+    if not matches:
+        return None
+    distinct = {s.session_id.full for s in matches}
+    if len(distinct) > 1:
+        where = ", ".join(sorted({s.project_path or "?" for s in matches}))
+        raise ToolError(
+            f"Session prefix {session!r} is ambiguous — it matches {len(distinct)} "
+            f"distinct sessions (in: {where}). Pass a longer id or scope with `projects`."
+        )
+    return matches[0]
+
+
 def _resolve_unique_session(
     all_sessions: list[SessionInfo], session: str
 ) -> SessionInfo:
@@ -467,17 +527,10 @@ def _resolve_unique_session(
     first/newest, surface the collision so the caller can disambiguate with a
     longer id or an explicit `projects` scope.
     """
-    matches = [s for s in all_sessions if PrefixId(s.session_id) == session]
-    if not matches:
+    target = _resolve_unique_session_or_none(all_sessions, session)
+    if target is None:
         raise ToolError(f"No session matching: {session}")
-    distinct = {s.session_id.full for s in matches}
-    if len(distinct) > 1:
-        where = ", ".join(sorted({s.project_path or "?" for s in matches}))
-        raise ToolError(
-            f"Session prefix {session!r} is ambiguous — it matches {len(distinct)} "
-            f"distinct sessions (in: {where}). Pass a longer id or scope with `projects`."
-        )
-    return matches[0]
+    return target
 
 
 def _filter_by_date(
@@ -1037,7 +1090,7 @@ def browse_session(
     session: Annotated[
         str,
         Field(
-            description="Session ID or prefix. Use list_project_sessions to find session IDs."
+            description="Session ID or prefix — also accepts a convert_session artifact's agent id, so you can browse a converted subagent's transcript (e.g. to read a turn UUID off it before rewind_transcript). Use list_project_sessions / list_session_agents to find IDs."
         ),
     ],
     projects: ProjectsParam = None,
@@ -1090,11 +1143,19 @@ def browse_session(
     if position not in ("head", "tail"):
         raise ToolError(f"position must be 'head' or 'tail', got: {position!r}")
 
+    # Session-first resolution: a real session id resolves via the parse-based
+    # corpus. Only when the id names NO session do we fall through to the
+    # filename-only artifact resolver, so a converted SUBAGENT's agent id browses
+    # like a session (rewind_transcript points users here to read its cut turn).
     narrowed = _projects_for_sessions([session], projects)
-    if not narrowed:
+    target: SessionInfo | None = None
+    if narrowed:
+        sessions, _ = _load_all_sessions(narrowed)
+        target = _resolve_unique_session_or_none(sessions, session)
+    if target is None:
+        target = _resolve_browsable_artifact(session, projects)
+    if target is None:
         raise ToolError(f"No session matching: {session}")
-    sessions, _ = _load_all_sessions(narrowed)
-    target = _resolve_unique_session(sessions, session)
 
     base_types = ENTRY_TYPE_MAP[role]
     entry_types = conversation_types_for(hide_set, base_types)
@@ -1630,7 +1691,7 @@ def rewind_transcript(
     ],
     turn: Annotated[
         str,
-        Field(description="Turn UUID (or prefix) to cut at — a user/assistant line in this transcript. Read it off browse_session / read_turn / grep_session run against the artifact."),
+        Field(description="Turn UUID (or prefix) to cut at — a user/assistant line in this transcript. Discover it by running browse_session / read_turn / grep_session against the artifact id itself (browse_session accepts a converted subagent's agent id). convert_session PRESERVES source turn UUIDs, so a turn id from the ORIGINAL session is also a valid cut point on the artifact."),
     ],
     cut: Annotated[
         Literal["after", "before"],

--- a/project-mining/src/cc_explorer/mcp_server.py
+++ b/project-mining/src/cc_explorer/mcp_server.py
@@ -434,6 +434,7 @@ class _ArtifactSession:
     session_id: PrefixId
     path: Path
     project_path: str
+    worktree: str | None = None
 
 
 def _sessions_by_filename(projects: list[str]) -> list[_ArtifactSession]:
@@ -452,7 +453,12 @@ def _sessions_by_filename(projects: list[str]) -> list[_ArtifactSession]:
                 continue
             seen.add(sid.full)
             out.append(
-                _ArtifactSession(session_id=sid, path=ref.path, project_path=proj)
+                _ArtifactSession(
+                    session_id=sid,
+                    path=ref.path,
+                    project_path=proj,
+                    worktree=ref.worktree,
+                )
             )
     return out
 
@@ -468,20 +474,22 @@ def _resolve_browsable_artifact(session: str, projects: list[str] | None) -> Ses
     `_sessions_by_filename` + `_resolve_artifacts_corpus`, NO transcript parse),
     which resolves the id to a subagent transcript path. We wrap that path in a
     minimal SessionInfo — `browse_session_turns` reads only `.path`, and the
-    response surfaces `.session_id` / `.project_path` — so the agent transcript
-    browses exactly like a session. Returns None when the id resolves to no
-    subagent (the caller keeps the original "no session matching" error).
+    response surfaces `.session_id` / `.project_path` / `.worktree` — so the agent
+    transcript browses exactly like a session. Returns None when the id resolves to
+    no subagent (the caller keeps the original "no session matching" error).
     """
     narrowed = _narrow_projects_for_artifacts([session], projects)
     sessions = _sessions_by_filename(narrowed)
     _, kind, full_id, path = _resolve_artifacts_corpus([session], sessions)[0]
     if kind != "subagent" or path is None:
         return None
-    # The artifact's holding project: the parent session whose dir is an ancestor
-    # of the agent transcript path (agents live under <session>/subagents/...).
-    project_path = next(
-        (s.project_path for s in sessions if s.path.parent in path.parents),
-        narrowed[0] if narrowed else None,
+    # The PARENT session holding this agent: its transcript dir (`<id>.jsonl`
+    # without the suffix → `<encoded>/<id>`) is an ancestor of the agent file
+    # (`<encoded>/<id>/subagents/agent-*.jsonl`). Match on that session dir, not
+    # `s.path.parent` (the encoded PROJECT dir), which every session in the project
+    # shares — so we surface the holding session's own project AND worktree.
+    holding = next(
+        (s for s in sessions if s.path.with_suffix("") in path.parents), None
     )
     return SessionInfo(
         session_id=PrefixId(full_id),
@@ -489,7 +497,8 @@ def _resolve_browsable_artifact(session: str, projects: list[str] | None) -> Ses
         title=f"subagent {full_id[:8]}",
         first_timestamp=None,
         message_count=0,
-        project_path=project_path,
+        project_path=holding.project_path if holding else (narrowed[0] if narrowed else None),
+        worktree=holding.worktree if holding else None,
     )
 
 

--- a/project-mining/tests/test_conversion.py
+++ b/project-mining/tests/test_conversion.py
@@ -1511,6 +1511,71 @@ def test_rewind_atomic_write_preserves_original_on_failure(fake_claude, monkeypa
     monkeypatch.setattr(conv.os, "replace", real_replace)
 
 
+def test_rewind_same_turn_twice_reports_already_rewound(fake_claude):
+    """Re-rewinding cut='before' the SAME turn reports 'already rewound', not 'not found'.
+
+    The first cut='before' CONSUMES its target (RW_T2 is the first line dropped),
+    so retrying the same rewind finds no matching line. The provenance line records
+    the prior cut (`rewound_to`), so the second attempt must say the artifact was
+    already rewound — the field-confusing case where success read as failure.
+    """
+    path = _lay_rw_subagent(fake_claude)
+
+    # First rewind cuts RW_T2 (and everything after) — it now records rewound_to.
+    srv.rewind_transcript(src_id=RW_AGENT, turn=RW_T2, cut="before")
+
+    with pytest.raises(ToolError) as exc:
+        srv.rewind_transcript(src_id=RW_AGENT, turn=RW_T2, cut="before")
+    msg = str(exc.value)
+    assert "already rewound" in msg
+    assert "not found" not in msg
+
+
+def test_rewind_unknown_turn_still_reports_not_found(fake_claude):
+    """A turn that was NEVER in the artifact still gets the generic 'not found'.
+
+    Guards against the already-rewound branch swallowing genuinely unknown turns:
+    the provenance has no `rewound_to` matching this id, so it must fall through.
+    """
+    path = _lay_rw_subagent(fake_claude)
+    # Rewind to a real turn so provenance carries SOME rewound_to (RW_A1, not below).
+    srv.rewind_transcript(src_id=RW_AGENT, turn=RW_A1, cut="after")
+
+    with pytest.raises(ToolError) as exc:
+        srv.rewind_transcript(
+            src_id=RW_AGENT, turn="deadbeef-0000-0000-0000-000000000000", cut="after"
+        )
+    msg = str(exc.value)
+    assert "not found" in msg
+    assert "already rewound" not in msg
+
+
+def test_browse_session_accepts_converted_subagent_id(fake_claude):
+    """browse_session resolves a converted subagent's agent id and returns its turns.
+
+    Closes the loop rewind_transcript depends on: the docstring tells users to read
+    a cut turn off browse_session run against the artifact, which only works if a
+    subagent agent id resolves here (it formerly returned 'No session matching').
+    """
+    path = _lay_rw_subagent(fake_claude)
+
+    resp = srv.browse_session(session=RW_AGENT, position="head", turns=10)
+
+    assert PrefixId(resp.session) == RW_AGENT
+    assert resp.total_turns == 4
+    # The four body turns are browsable (ONE/TWO/THREE/FOUR live in the display).
+    joined = " ".join(resp.chats)
+    assert "ONE" in joined and "FOUR" in joined
+
+
+def test_browse_session_unknown_id_still_errors(fake_claude):
+    """An id matching no session AND no subagent still raises 'No session matching'."""
+    _lay_rw_subagent(fake_claude)
+    with pytest.raises(ToolError) as exc:
+        srv.browse_session(session="ffffffff-0000-0000-0000-000000000000")
+    assert "No session matching" in str(exc.value)
+
+
 # =============================================================================
 # Conversion reaper — lifespan-driven GC of pristine, cold artifacts
 # =============================================================================

--- a/project-mining/uv.lock
+++ b/project-mining/uv.lock
@@ -112,7 +112,7 @@ wheels = [
 
 [[package]]
 name = "cc-explorer"
-version = "1.38.1"
+version = "1.38.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## The field confusion

A rewind that **succeeded** read as a tool that **broke the artifact**, because two issues compounded:

1. **Rewind success misread as failure.** Rewinding `cut="before"` a turn, then re-running the *same* rewind, returned a cryptic `turn '<uuid>' not found in this transcript`. The retry "failed" only because the first rewind already CUT that turn — it's gone. The artifact's provenance line already records the cut (`rewound_to`, `rewound_at`), so the tool had everything it needed to say "already rewound" but instead said "not found".

2. **Closed-loop turn discovery.** The user couldn't inspect the artifact to find its turn UUIDs: `browse_session` only resolved SESSION ids, so passing a converted subagent's agent id returned `No session matching: <agentid>`. Yet `rewind_transcript`'s docstring points users at `browse_session` "run against the artifact" — a path that was closed for a subagent artifact.

## The fixes

- **Fix 1 — `conversion.py:rewind_transcript`.** Before raising the generic "not found", it now checks the provenance sentinel (`read_provenance`): when the requested turn equals/prefix-matches a prior `rewound_to`, it raises a specific "already rewound to `<rewound_to>` at `<rewound_at>` … nothing to do" message. Genuinely unknown turns still get the generic "not found".
- **Fix 2 — `mcp_server.py:browse_session`.** Session-first resolution is preserved; when the id names no session it falls through to the same filename-only artifact resolver rewind/delete use (`_narrow_projects_for_artifacts` + `_sessions_by_filename` + `_resolve_artifacts_corpus`, no transcript parse), wrapping the agent transcript path in a minimal `SessionInfo` so a converted subagent browses like a session. The `session` param description now advertises this.
- **Fix 3 — rewind docstring.** The `turn` description now reflects that `browse_session` works on the artifact id, and notes that `convert_session` preserves source turn UUIDs (so a turn id from the original session is a valid cut point — the practical discovery path).

## Tests

Added to `tests/test_conversion.py`: same-turn double `cut="before"` rewind reports "already rewound" (not "not found"); an unknown turn still gets the generic "not found" (regression guard); `browse_session` on a converted subagent's agent id returns its turns; an unknown id still raises "No session matching". Each new test was verified to go red against a deliberately broken fix and green when restored.

Full suite: **355 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)