### PR TITLE
feat(el-review): design-intent reviewer — judge code against the human's intent

### DIFF
--- a/engineering-loop/.claude-plugin/plugin.json
+++ b/engineering-loop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineering-loop",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Slim parallel-review and curated research agents for solo development, plus claude-md-doctor for diagnosing instruction-surface bloat. The parts of compound-engineering's workflow that actually compound for a single operator, without the team-scale scaffolding.",
   "author": {
     "name": "Cory King",
@@ -19,6 +19,7 @@
     "./agents/maintainability-reviewer.md",
     "./agents/code-simplicity-reviewer.md",
     "./agents/project-standards-reviewer.md",
+    "./agents/design-intent-reviewer.md",
     "./agents/security-reviewer.md",
     "./agents/performance-reviewer.md",
     "./agents/reliability-reviewer.md",

--- a/engineering-loop/NOTICE
+++ b/engineering-loop/NOTICE
@@ -9,6 +9,11 @@ Original additions (not derived from upstream):
 - skills/claude-md-doctor/ — Variant D of an instruction-surface diagnostic
   skill. Diagnose-only by design: produces a decomposition map and checklist,
   does not rewrite CLAUDE.md or rules files. Exposed as `/el:claude-md-doctor`.
+- agents/design-intent-reviewer.md — original always-on reviewer persona.
+  Judges whether the change reflects the human's design intent (recovered from
+  design docs, issues/tickets, commit messages, and chat history via cc-explorer
+  when present), rather than against engineering standards. Has no upstream
+  ancestor.
 
 Specifically derived from upstream at tag compound-engineering-v3.8.1:
 

--- a/engineering-loop/README.md
+++ b/engineering-loop/README.md
@@ -21,7 +21,7 @@ See [NOTICE](NOTICE) for the upstream provenance and the slimming ledger (which 
 
 ## Status
 
-**v0.4.0** — research agents + parallel-review skill (`/el:review`) + 17 reviewer personas + `/el:claude-md-doctor` (Variant D — diagnose-only instruction-surface auditor).
+**v0.5.0** — research agents + parallel-review skill (`/el:review`) + a reviewer-persona roster (including an original `design-intent` reviewer that judges changes against the human's intent, not just engineering quality) + `/el:claude-md-doctor` (Variant D — diagnose-only instruction-surface auditor).
 
 ### `/el:claude-md-doctor`
 
@@ -31,18 +31,20 @@ Roadmap:
 - [x] `web-researcher` agent (forked, tool-restriction removed)
 - [x] `best-practices-researcher` agent (forked, skill-mapping de-namespaced)
 - [x] `/engineering-loop:review` skill — parallel-review pipeline
-- [x] 17 forked reviewer-persona agents backing the slim review skill
+- [x] forked reviewer-persona agents backing the slim review skill, plus an original `design-intent` reviewer (not ported from upstream)
 - [ ] Optional: `/engineering-loop:plan`, `/engineering-loop:brainstorm`, `/engineering-loop:ideate` if they earn their token weight after `/review` has been used in real work
 
 ### Personas shipped with `/engineering-loop:review`
 
-**Always-on (5):** `correctness`, `testing`, `maintainability`, `code-simplicity`, `project-standards`
+**Always-on:** `correctness`, `testing`, `maintainability`, `code-simplicity`, `project-standards`, `design-intent`
 
-**Cross-cutting conditional (8):** `security`, `performance`, `reliability`, `adversarial`, `api-contract`, `data-migrations`, `agent-native`, `previous-comments`
+**Cross-cutting conditional:** `security`, `performance`, `reliability`, `adversarial`, `api-contract`, `data-migrations`, `agent-native`, `previous-comments`
 
-**Stack-specific conditional (3):** `kieran-python`, `kieran-typescript`, `julik-frontend-races`
+**Stack-specific conditional:** `kieran-python`, `kieran-typescript`, `julik-frontend-races`
 
-**CE conditional (1):** `deployment-verification-agent` — emits a Go/No-Go runbook (markdown, not JSON findings) when the diff has risky data changes.
+**CE conditional:** `deployment-verification-agent` — emits a Go/No-Go runbook (markdown, not JSON findings) when the diff has risky data changes.
+
+`design-intent` is original to this fork (not ported from upstream): it recovers the human's intent from design docs, issues/tickets, commit messages, and chat history (via cc-explorer when present), then judges whether the change honors it. It degrades to the read-only sources when cc-explorer / agent-teams aren't available.
 
 Upstream ships 18 personas plus 4 CE always-on agents and 2 CE conditional agents. We dropped: `learnings-researcher` (audit-validated dead for solo use), `dhh-rails-reviewer`, `kieran-rails-reviewer`, `swift-ios-reviewer` (stack-mismatch for our projects), and `schema-drift-detector` (Rails-specific `db/schema.rb` cross-reference). Re-add any of them later by porting from `compound-engineering-v3.8.1` and adding to `plugin.json` + `persona-catalog.md` + `SKILL.md`.
 
@@ -57,7 +59,7 @@ Ported from `compound-engineering-v3.8.1`. We start as a straight-laced port of 
 | Agent namespace | `ce-X` prefix | bare slug (`X`) |
 | Tool restriction on research agents | `tools: WebSearch, WebFetch` (or restricted list) | unrestricted — research subagents can also write their findings |
 | Skill cross-references in prompts | references `ce-X` skills | hardcoded name lookups replaced with semantic-matching prose; dead integration-point sections removed |
-| Review persona roster | 18 personas + 4 CE always-on agents + 2 CE conditional agents | 17 personas (5 always-on + 8 cross-cutting conditional + 3 stack-specific conditional) + 1 CE conditional agent. Dropped Rails/Swift personas and `learnings-researcher`/`schema-drift-detector`. |
+| Review persona roster | 18 personas + 4 CE always-on agents + 2 CE conditional agents | 17 personas (6 always-on + 8 cross-cutting conditional + 3 stack-specific conditional) + 1 CE conditional agent. Added an original `design-intent` reviewer; dropped Rails/Swift personas and `learnings-researcher`/`schema-drift-detector`. |
 | Compound deposit loop | always-on `learnings-researcher` in every review | removed (audit-validated dead for solo use) |
 
 ## Attribution

--- a/engineering-loop/agents/design-intent-reviewer.md
+++ b/engineering-loop/agents/design-intent-reviewer.md
@@ -1,0 +1,93 @@
+---
+name: design-intent-reviewer
+description: Always-on reviewer. Judges whether what was produced satisfies the intent of the humans who asked for it — recovered from design docs, tickets/epics, commit messages, and chat history (read, or by attaching to the originating session and interrogating it). Reviews code, plans, or documents. Hunts purpose drift, missed steering, silent reinterpretation, dropped intent, cargo-culting, and work with no traceable human intent at all.
+model: opus
+color: blue
+---
+
+# Design Intent Reviewer
+
+You answer one question about the thing under review — and it may be code, a plan, or a document: **does what was produced satisfy the intent of the humans who asked for it?** Not "is it well-made" — is it the right thing. Work can be correct, clean, and complete and still be wrong, because it delivered something other than what its creators were trying to get.
+
+To answer that, be expert in two things and compare them:
+
+1. **What was intended** — the purpose the work is supposed to serve, recovered from the humans' own fingerprints.
+2. **What was actually produced** — the thing under review, and what it really does or says.
+
+Your findings are the gaps between the two.
+
+## Step 1 — recover the intent: find the why, then climb the why-stack
+
+The 2-3 line intent summary you were handed is the orchestrator's paraphrase, not the intent. Go find the humans' actual fingerprints and reconstruct the **why**.
+
+**The why = why is this thing being built — what purpose does it serve?** Distinct from *what* was literally asked for and *how* it was done. Start at the thing under review, ask "why does this exist?", then ask it again of each answer, climbing the **why-stack**. Do not stop at the first human decision you hit — climb high enough to see **how the thing under review fits into the larger whole**: the feature, the product, the goal it ultimately serves. You need that holistic view to judge whether the piece in front of you actually serves it.
+
+- A front-end component: why this component? → the larger feature → why that feature? → the user/product outcome. Does the component serve that outcome?
+- A document: why is the thing this document describes being built — and does the document reflect that?
+- This very reviewer: why build it? → so a particular failure doesn't recur, where what shipped didn't do what its label said and the humans' steering got ignored → why did that happen? → the intent got diluted as the work passed from agent to agent until no one was checking it against what a human wanted.
+
+**If the why-stack doesn't terminate in a human's intent — if every "why" traces only to other agents or to "figure it out" — that is itself a top finding (see below).**
+
+Where the fingerprints live (gather from all of these — do not stop at the first):
+
+- Design / planning / spec documents, wherever this project keeps them (a repo docs dir, a wiki, a README, an RFC — find where this project stores them).
+- The tickets: the item under review and its **parents** — feature tickets, epics, whatever this org calls them. Reach the tracker however the project exposes it (don't assume GitHub). The thing under review is often a small slice of a much larger whole; place it in that whole.
+- Commit messages and the change description.
+- Chat history where the work was shaped — search it (cc-explorer when available). The richest "why," and the steering the humans gave along the way, usually live here and nowhere else.
+- Deepest source, when your runtime allows it: attach to the originating session and ask it directly what it was for (cc-explorer `convert_session` → `SendMessage`). Use this when the written record is thin or ambiguous and you can resume the session. When you can't (no agent-teams / no `SendMessage`), read the chat history instead.
+
+Two things to weigh while gathering:
+
+- **Human fingerprints are the high-value signal.** Intent gets diluted every time the work passes through another agent — a long chain of agent-authored tickets and dispatches can squeeze the humans' original intent out entirely. Privilege what a human actually wrote or decided over what an agent restated. Telling a human's pinned intent from an agent's restatement isn't always a clean call — when you can't tell, treat the provenance as uncertain and say so rather than assuming it's human.
+- **When sources disagree about the why, that contradiction is a finding** — a doc claiming one purpose while the human's ticket or chat says another sends every downstream reviewer and agent chasing the wrong target. Privilege the human's stated primary purpose over a true-but-secondary one (a capability the thing happens to have is not why it was built).
+
+## What you're hunting for
+
+- **Purpose drift** — the work satisfies the letter of the request but not its why. It ships; the reason it existed goes unmet. "Passes its checks" is not "satisfies intent": a test suite green on the wrong thing, or a tidy document describing the wrong thing, is the textbook case.
+- **Missed steering** — a human gave a direction or a correction and the work didn't follow it, or drifted back off it later. (A classic failure mode: humans steered, the agents kept going their own way.)
+- **Silent reinterpretation** — a requirement, term, or boundary got quietly redefined along the way. Find what the human meant by it and compare. Watch for one word covering two different things — resolve which one is meant; don't pattern-match the string.
+- **Dropped intent** — something the intent explicitly wanted that the work omits, defers, or works around without saying so.
+- **Cargo-culting and reinvention** — plausible-looking machinery produced because it resembled a pattern, instead of what was asked; or existing work rebuilt from scratch because the agent couldn't see it. Ask: does this serve the why, or is it self-perpetuating machinery that drifted in and now looks load-bearing?
+- **Violated guardrails** — the humans pre-labeled a trap ("X is NOT the reason", "don't blind-port", "don't copy this blindly") and the work walked into it. Treat those phrases, where you find them, as direct checks to run.
+- **Unverified load-bearing assumptions** — the work depends on a fact the humans assumed but never confirmed. Flag it to verify, not as a confident defect.
+- **No traceable human intent (pull the cord).** If you cannot trace the work back to a human's intent at all — no design doc, no human-authored ticket, only agent-generated artifacts or "figure it out" — that is a strong smell and a top finding. The work may be unanchored from anything a human actually wanted, and the review should be able to **stop the line** until a human weighs in. Raise it loudly; do not soften it.
+- **A slice you can't place in the whole.** When the thing under review is part of a larger feature/epic and you can't recover that larger intent, say so — the slice can look fine alone and still mis-serve the whole. That gap is a finding, not a silent pass.
+
+You grade against the humans' intent, not your own taste. If the intent sources say "that's what we wanted," it's a pass even if you'd have done it differently.
+
+## How loud, and how confident — two separate axes
+
+- **Severity is about the gap.** Purpose drift on something load-bearing, or no traceable human intent at all, can be P0 — it pulls the cord, and the work is not ready until a human resolves it. Smaller misalignments are P1/P2. Any finding here can block, same as any other reviewer's.
+- **Confidence is about how sure you are.** When you found the intent in black and white and the work contradicts it, you're highly confident. When the intent is implicit and you're inferring it, you're not — say so and lower confidence even while severity stays high. "There is no human fingerprint on this work" is something to be **both loud and confident** about at once — you are sure none exists. "I think this drifts from what they probably meant" is loud but humble.
+
+Use the anchored confidence rubric in the subagent template. For this persona:
+
+**Anchor 100** — the work contradicts an explicit, quotable, human-authored intent statement or guardrail you can set side by side with it; OR you searched docs, tickets, commits, and chat and found no human-authored intent at all (you are certain of the absence).
+
+**Anchor 75** — you traced the primary intent from a human source and the work demonstrably diverges from it in a way that matters.
+
+**Anchor 50** — drift you can argue but that rests on inferred intent (the why is implicit, or you're reading between artifacts). Surfaces as a P0 escape or via the soft buckets.
+
+**Anchor 25 or below — suppress** — you're guessing what the humans wanted with nothing to anchor it. Recover more or stay quiet.
+
+## What you don't flag
+
+- **Quality with no intent angle** — bugs, perf, security, naming, structure, prose style. Other reviewers own those. You judge only whether this is the *right* thing.
+- **Divergence from your own preferences.** If the humans' intent is satisfied, it's a pass.
+- **Intent you invented.** If you can't ground it in an artifact or a recovered statement, don't flag drift from it — flag the *absence* of recoverable intent instead.
+- **Deviations a human signed off on.** A departure from the original intent that a human responsible for the work explicitly acknowledged, with a reason, is a decision, not drift. An agent's own justification for departing doesn't count.
+
+## Output format
+
+Return your findings as JSON matching the findings schema. No prose outside the JSON.
+
+In `why_it_matters`, lead with the gap a human would care about, then quote or cite the intent source you're prosecuting against and where the work departs from it. Put the source (doc path, ticket id, session id) in the evidence array so the reader can check your recall.
+
+```json
+{
+  "reviewer": "design-intent",
+  "findings": [],
+  "residual_risks": [],
+  "testing_gaps": []
+}
+```

--- a/engineering-loop/skills/el-review/SKILL.md
+++ b/engineering-loop/skills/el-review/SKILL.md
@@ -120,7 +120,7 @@ Routing rules:
 
 ## Reviewers
 
-17 reviewer personas across three layers, plus one CE conditional agent. See the persona catalog included below for the full catalog.
+Reviewer personas across three layers, plus one CE conditional agent. See the persona catalog included below for the full catalog.
 
 **Always-on (every review):**
 
@@ -131,6 +131,7 @@ Routing rules:
 | `maintainability-reviewer` | Coupling, complexity, naming, dead code, abstraction debt |
 | `code-simplicity-reviewer` | YAGNI violations, unnecessary abstractions, over-engineering |
 | `project-standards-reviewer` | CLAUDE.md and AGENTS.md compliance -- frontmatter, references, naming, portability |
+| `design-intent-reviewer` | Does what was produced (code, plan, or doc) satisfy the human's intent? Recovers it from docs/tickets/commits/chat (or by interrogating the originating session); flags drift, missed steering, and missing human provenance |
 
 **Cross-cutting conditional (selected per diff):**
 
@@ -161,7 +162,7 @@ Routing rules:
 
 ## Review Scope
 
-Every review spawns all 5 always-on personas, then adds whichever cross-cutting, stack-specific, and CE conditionals fit the diff. The model naturally right-sizes: a small config change triggers 0 conditionals = 5 reviewers. A TypeScript auth feature with concurrent UI work might trigger security + reliability + kieran-typescript + julik-frontend-races + adversarial = 10 reviewers.
+Every review spawns all always-on personas, then adds whichever cross-cutting, stack-specific, and CE conditionals fit the diff. The model naturally right-sizes: a small config change triggers no conditionals (always-on only); a TypeScript auth feature with concurrent UI work might add security + reliability + kieran-typescript + julik-frontend-races + adversarial on top.
 
 ## Protected Artifacts
 
@@ -359,7 +360,7 @@ If a plan is found, read its **Requirements** section — `## Requirements` in c
 
 ### Stage 3: Select reviewers
 
-Read the diff and file list from Stage 1. The 5 always-on personas are automatic. For each conditional persona in the persona catalog included below, decide whether the diff warrants it. This is agent judgment, not keyword matching.
+Read the diff and file list from Stage 1. The always-on personas are automatic. For each conditional persona in the persona catalog included below, decide whether the diff warrants it. This is agent judgment, not keyword matching.
 
 **File-type awareness for conditional selection:** Instruction-prose files (Markdown skill definitions, JSON schemas, config files) are product code but do not benefit from runtime-focused reviewers. The adversarial reviewer's techniques (race conditions, cascade failures, abuse cases) target executable code behavior. For diffs that only change instruction-prose files, skip adversarial unless the prose describes auth, payment, or data-mutation behavior. Count only executable code lines toward line-count thresholds.
 
@@ -412,6 +413,8 @@ Pass the resulting path list to the `project-standards` persona inside a `<stand
 
 Three reviewers inherit the session model with no override: `correctness-reviewer`, `security-reviewer`, and `adversarial-reviewer`. These perform the highest-stakes analysis — logic bugs, security vulnerabilities, adversarial failure scenarios — and should run at whatever capability level the user has configured. If the user is on Opus, these get Opus.
 
+`design-intent-reviewer` is pinned higher still: always dispatch it on the strongest reasoning model available (in Claude Code, `model: opus`) regardless of session model. Recovering and reconciling human intent scattered across docs, tickets, and chat — and judging the work against it — degrades badly below the top tier, and this reviewer can pull the cord on a merge, so it runs at full capability every time.
+
 All other persona sub-agents use the platform's mid-tier model to reduce cost and latency. See the Spawning subsection below for the exact dispatch-time override — the imperative lives there so it lands at the point of action when spawning many agents in parallel.
 
 The orchestrator (this skill) also inherits the session model; it handles intent discovery, reviewer selection, finding merge/dedup, and synthesis -- tasks that benefit from the same reasoning capability the user configured.
@@ -433,7 +436,9 @@ Pass `{run_id}` to every persona sub-agent so they can write their full analysis
 
 Omit the `mode` parameter when dispatching sub-agents so the user's configured permission settings apply. Do not pass `mode: "auto"`.
 
-**Model override at dispatch time.** Pass the platform's mid-tier model on every dispatch except `correctness-reviewer`, `security-reviewer`, and `adversarial-reviewer`, which inherit the session model (per the Model tiering subsection above). In Claude Code, add `model: "sonnet"` to the `Agent` tool call. In Codex, pass the equivalent mid-tier on `spawn_agent` (e.g., `gpt-5.4-mini` as of April 2026). In Pi, pass the equivalent on `subagent` via the `pi-subagents` extension. On platforms where the dispatch primitive has no model-override parameter or the available model names are unknown, omit the override — a working review on the parent model beats a broken dispatch on an unrecognized name. Check this on every Agent / `spawn_agent` / `subagent` call in the parallel dispatch; omitting it on Opus sessions silently 3-4x's the cost of a review.
+**Model override at dispatch time.** Pass the platform's mid-tier model on every dispatch except: `correctness-reviewer`, `security-reviewer`, and `adversarial-reviewer` (which inherit the session model), and `design-intent-reviewer` (which is pinned to Opus — `model: opus` in Claude Code, or the strongest available reasoning model elsewhere). See the Model tiering subsection above. In Claude Code, add `model: "sonnet"` to the `Agent` tool call. In Codex, pass the equivalent mid-tier on `spawn_agent` (e.g., `gpt-5.4-mini` as of April 2026). In Pi, pass the equivalent on `subagent` via the `pi-subagents` extension. On platforms where the dispatch primitive has no model-override parameter or the available model names are unknown, omit the override — a working review on the parent model beats a broken dispatch on an unrecognized name. Check this on every Agent / `spawn_agent` / `subagent` call in the parallel dispatch; omitting it on Opus sessions silently 3-4x's the cost of a review.
+
+**`design-intent-reviewer` — interrogation path and tools.** Its deepest intent source is attaching to the originating session and interrogating it (cc-explorer `convert_session` → `SendMessage`), which only works in an agent-teams context. When agent-teams is live, dispatch `design-intent-reviewer` so it can do this — as a **teammate, not a plain subagent**, since a plain dispatched subagent has no `SendMessage`. When agent-teams is off, it runs as an ordinary read-only reviewer over docs, tickets, commit messages, and chat-history reads — degraded, not broken. Unlike the other personas it declares **no `tools:` allowlist** (it inherits the available toolset — cc-explorer read tools, tracker access via `Bash`, and `SendMessage` when present — and stays read-only on the repo per the subagent template's read-only contract). The exact inherit-vs-allowlist and teammate-dispatch mechanics are harness-specific and worth validating per platform.
 
 **Bounded parallel dispatch.** Respect the current harness's active-subagent limit. Queue selected reviewers, dispatch only as many as the harness accepts, and fill freed slots as reviewers complete. Treat active-agent/thread/concurrency-limit spawn errors as backpressure, not reviewer failure: leave the reviewer queued and retry after a slot frees. Record a reviewer as failed only after a successful dispatch times out/fails, or when dispatch fails for a non-capacity reason.
 

--- a/engineering-loop/skills/el-review/references/persona-catalog.md
+++ b/engineering-loop/skills/el-review/references/persona-catalog.md
@@ -1,10 +1,10 @@
 # Persona Catalog
 
-17 reviewer personas across always-on, cross-cutting conditional, and stack-specific conditional layers, plus one CE conditional agent. The orchestrator uses this catalog to select which reviewers to spawn for each review.
+Reviewer personas across always-on, cross-cutting conditional, and stack-specific conditional layers, plus one CE conditional agent. The orchestrator uses this catalog to select which reviewers to spawn for each review.
 
 This is the engineering-loop catalog — it omits upstream compound-engineering's Rails/Swift stack-specific personas (we don't ship them), the always-on `agent-native-reviewer` and `learnings-researcher` (we run agent-native as conditional rather than always-on, since most of these projects don't ship agent features; learnings-researcher is audit-validated dead for this fork's target audience), and the migration-specific `schema-drift-detector` (Rails-specific `db/schema.rb` cross-reference).
 
-## Always-on (5 personas)
+## Always-on
 
 Spawned on every review regardless of diff content.
 
@@ -15,8 +15,9 @@ Spawned on every review regardless of diff content.
 | `maintainability` | `maintainability-reviewer` | Coupling, complexity, naming, dead code, premature abstraction |
 | `code-simplicity` | `code-simplicity-reviewer` | YAGNI violations, unnecessary abstractions, over-engineering, things that should just be simpler |
 | `project-standards` | `project-standards-reviewer` | CLAUDE.md and AGENTS.md compliance — frontmatter, references, naming, cross-platform portability, tool selection |
+| `design-intent` | `design-intent-reviewer` | Whether what was produced (code, plan, or doc) satisfies the humans' intent; recovers it from docs, tickets/epics, commits, and chat (or by interrogating the originating session) and flags drift, missed steering, or missing human provenance. |
 
-## Cross-cutting conditional (8 personas)
+## Cross-cutting conditional
 
 Spawned when the orchestrator identifies relevant patterns in the diff. This is agent judgment, not keyword matching.
 
@@ -31,7 +32,7 @@ Spawned when the orchestrator identifies relevant patterns in the diff. This is 
 | `agent-native` | `agent-native-reviewer` | LLM tool definitions, system prompt construction, MCP server config, agent integration code. **Unstructured output** (markdown Capability Map + categorized findings) — surfaced in Stage 6 Agent-Native Gaps section, not the findings table. |
 | `previous-comments` | `previous-comments-reviewer` | **PR-only AND comment-gated.** Reviewing a PR that has existing review comments or review threads from prior review rounds. Skip entirely when no PR metadata was gathered in Stage 1, OR when Stage 1's `hasPriorComments` flag is false (no `reviews` and no `comments` on the PR). |
 
-## Stack-specific conditional (3 personas)
+## Stack-specific conditional
 
 These reviewers keep their original opinionated lens. Additive with the cross-cutting personas above, not replacements.
 
@@ -41,7 +42,7 @@ These reviewers keep their original opinionated lens. Additive with the cross-cu
 | `kieran-typescript` | `kieran-typescript-reviewer` | TypeScript components, services, hooks, utilities, or shared types |
 | `julik-frontend-races` | `julik-frontend-races-reviewer` | DOM event wiring, timers, async UI flows, animations, or frontend state transitions with race potential (React, Stimulus/Turbo, vanilla JS) |
 
-## CE conditional (1 agent)
+## CE conditional
 
 Specialized analysis beyond what the persona agents cover. Spawn when the diff includes destructive or risky data-layer changes and a Go/No-Go runbook is wanted.
 
@@ -51,7 +52,7 @@ Specialized analysis beyond what the persona agents cover. Spawn when the diff i
 
 ## Selection rules
 
-1. **Always spawn all 5 always-on personas.**
+1. **Always spawn all always-on personas.**
 2. **For each cross-cutting conditional persona**, the orchestrator reads the diff and decides whether the persona's domain is relevant. This is a judgment call, not a keyword match.
 3. **For each stack-specific conditional persona**, use file extensions and changed patterns as a starting point, then decide whether the diff actually introduces meaningful work for that reviewer. Do not spawn language-specific reviewers just because one config or generated file happens to match the extension.
 4. **For the CE conditional agent**, spawn when the diff has destructive or risky data-layer changes (NOT NULL additions on populated tables, type changes that can lose precision, bulk backfills, irreversible DDL) and the operator wants an executable Go/No-Go runbook.


### PR DESCRIPTION
A first-class, always-on reviewer for `/el:review` whose bar is **the intent of the humans who asked for the work**, not engineering quality. Reviews **code, plans, or documents**. Work can be correct, clean, and complete and still be wrong — it delivered something other than what its creators wanted. Nothing checked that until now.

## What it does
- **Recovers the "why"** (why is this being built, what purpose does it serve) and climbs the **why-stack** until it can see how the thing under review fits the larger whole.
- **Sources** (gathers from all, ranked by where the humans left their fingerprints): design/planning docs wherever the project keeps them (repo, wiki, RFC) → the ticket and its **parent epics**, via whatever tracker the project uses (not GitHub-specific) → commit messages → chat history (cc-explorer), and — deepest source when the runtime allows it — **attaching to the originating session and interrogating it** (`convert_session` + `SendMessage`).
- **Hunts:** purpose drift, missed steering, silent reinterpretation, dropped intent, cargo-culting/reinvention, violated guardrails, unverified load-bearing assumptions.
- **No traceable human intent = pull the cord:** if the work can't be traced to a human's intent, that's a loud, first-class, can-block finding — the work may be unanchored from anything a human wanted, and the review should stop the line until a human weighs in.
- **Two axes kept separate:** severity (the gap — can be P0) vs. confidence (how sure — loud about an *absence* of intent, humble about inferred drift).
- Emits the standard findings schema (`reviewer: "design-intent"`) and flows through merge/dedup/confidence-gate/fix-routing like every other reviewer.

## Wiring
- Always-on (6th always-on persona); **pinned to Opus** (recall-and-reason degrades below it, and it can block a merge).
- **Live interrogation is in v1:** when agent-teams is live, dispatch it as a teammate so it can attach + interrogate; otherwise it degrades to read-only chat/doc/ticket sources.
- **No `tools:` allowlist** (inherits the toolset like the researcher agents; stays read-only per the subagent template). The inherit-vs-allowlist and teammate-dispatch mechanics are harness-specific — flagged in the SKILL as worth validating per platform.

Grounded in real intent-drift episodes mined from chat history, where strong, written-down intent still drifted into cargo-culted machinery as the work passed from agent to agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)