### PR TITLE
feat(el-review): project-custom reviewers via el-review:true flag (#52)

### DIFF
--- a/engineering-loop/.claude-plugin/plugin.json
+++ b/engineering-loop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "engineering-loop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Slim parallel-review and curated research agents for solo development, plus claude-md-doctor for diagnosing instruction-surface bloat. The parts of compound-engineering's workflow that actually compound for a single operator, without the team-scale scaffolding.",
   "author": {
     "name": "Cory King",

--- a/engineering-loop/README.md
+++ b/engineering-loop/README.md
@@ -21,7 +21,7 @@ See [NOTICE](NOTICE) for the upstream provenance and the slimming ledger (which 
 
 ## Status
 
-**v0.5.0** — research agents + parallel-review skill (`/el:review`) + a reviewer-persona roster (including an original `design-intent` reviewer that judges changes against the human's intent, not just engineering quality) + `/el:claude-md-doctor` (Variant D — diagnose-only instruction-surface auditor).
+**v0.6.0** — research agents + parallel-review skill (`/el:review`) + a reviewer-persona roster (including an original `design-intent` reviewer that judges changes against the human's intent, not just engineering quality) + per-project reviewer extensibility (a repo's own `.claude/agents/` reviewers opt in via `el-review: true`) + `/el:claude-md-doctor` (Variant D — diagnose-only instruction-surface auditor).
 
 ### `/el:claude-md-doctor`
 
@@ -43,6 +43,8 @@ Roadmap:
 **Stack-specific conditional:** `kieran-python`, `kieran-typescript`, `julik-frontend-races`
 
 **CE conditional:** `deployment-verification-agent` — emits a Go/No-Go runbook (markdown, not JSON findings) when the diff has risky data changes.
+
+**Project-custom:** the repo under review can contribute its own domain reviewers. Any agent in the project's `.claude/agents/*.md` that opts in with `el-review: true` in its frontmatter is discovered and selected per-diff by its `description`, then runs through the same merge pipeline as the built-ins — a domain lens too specific to ship here (a finance project's cash-flow-modeling reviewer, say) without forking this plugin. See `persona-catalog.md` for the author contract.
 
 `design-intent` is original to this fork (not ported from upstream): it recovers the human's intent from design docs, issues/tickets, commit messages, and chat history (via cc-explorer when present), then judges whether the change honors it. It degrades to the read-only sources when cc-explorer / agent-teams aren't available.
 

--- a/engineering-loop/skills/el-review/SKILL.md
+++ b/engineering-loop/skills/el-review/SKILL.md
@@ -160,9 +160,13 @@ Reviewer personas across three layers, plus one CE conditional agent. See the pe
 |-------|--------------------|
 | `deployment-verification-agent` | Includes risky data changes (migrations, backfills, irreversible DDL) that warrant a Go/No-Go runbook with verification queries and rollback procedures |
 
+**Project-custom (per-project, opt-in):**
+
+The consuming repo can contribute its own domain reviewers. Any agent in the target repo's `.claude/agents/*.md` that opts in with `el-review: true` in its frontmatter is discovered and selected per-diff like a conditional persona, keyed on its own `description`. See the persona catalog's "Project-custom conditional" layer for the discovery and author contract.
+
 ## Review Scope
 
-Every review spawns all always-on personas, then adds whichever cross-cutting, stack-specific, and CE conditionals fit the diff. The model naturally right-sizes: a small config change triggers no conditionals (always-on only); a TypeScript auth feature with concurrent UI work might add security + reliability + kieran-typescript + julik-frontend-races + adversarial on top.
+Every review spawns all always-on personas, then adds whichever cross-cutting, stack-specific, CE, and opted-in project-custom conditionals fit the diff. The model naturally right-sizes: a small config change triggers no conditionals (always-on only); a TypeScript auth feature with concurrent UI work might add security + reliability + kieran-typescript + julik-frontend-races + adversarial on top.
 
 ## Protected Artifacts
 
@@ -377,6 +381,12 @@ For stack-specific personas, use file extensions and changed patterns as a start
 
 For the CE conditional `deployment-verification-agent`, spawn it when the diff includes destructive or risky data-layer changes — `NOT NULL` additions on populated tables, type changes that can lose precision, bulk backfills, irreversible DDL — and the operator wants an executable Go/No-Go runbook (SQL invariant queries, deploy steps with rollback per step, post-deploy monitoring plan). Not every migration warrants it; reserve it for changes where guessing at launch time is unacceptable.
 
+**Project-custom reviewers.** The repo under review may ship its own domain reviewers (a project's `financial-modeling-reviewer`, `schema-conventions-reviewer`, etc.) that are too specific to live in the built-in roster but are exactly the lens that should run for *that* project. Discover and select them as a fourth conditional layer:
+
+1. **Discover.** Using the native file-search/glob tool, find `.claude/agents/*.md` at the root of the repo under review (the same target checkout Stage 3b globs for standards files). Read each one's frontmatter and keep only agents with `el-review: true`. Agents without the flag are ordinary project agents, not reviewers — ignore them. If the directory is absent or no agent opts in, this layer is empty; proceed normally.
+2. **Select.** For each opted-in agent, treat its frontmatter `description` (its "invoke when…" clause) as the conditional selection criterion and apply the same judgment you apply to a built-in cross-cutting conditional: does this diff fall in the agent's stated domain? Select it when it does. These are additive to the built-in layers, never replacements.
+3. **Dispatch.** Spawn selected project-custom reviewers through the same Stage 4 path as built-in personas — see Stage 4 for the dispatch mechanics and the model-tiering exemption. Their structured findings merge through Stage 5 keyed by the `reviewer` name they emit; no special handling.
+
 Announce the team before spawning:
 
 ```
@@ -394,6 +404,7 @@ Review team:
 - adversarial -- diff is 80+ lines and touches auth boundary
 - previous-comments -- PR has 4 prior review threads
 - deployment-verification-agent -- migration adds NOT NULL on populated 170k-row table
+- financial-modeling (project-custom) -- diff touches the lifetime cash-flow model
 ```
 
 This is progress reporting, not a blocking confirmation.
@@ -438,7 +449,11 @@ Omit the `mode` parameter when dispatching sub-agents so the user's configured p
 
 **Model override at dispatch time.** Pass the platform's mid-tier model on every dispatch except: `correctness-reviewer`, `security-reviewer`, and `adversarial-reviewer` (which inherit the session model), and `design-intent-reviewer` (which is pinned to Opus — `model: opus` in Claude Code, or the strongest available reasoning model elsewhere). See the Model tiering subsection above. In Claude Code, add `model: "sonnet"` to the `Agent` tool call. In Codex, pass the equivalent mid-tier on `spawn_agent` (e.g., `gpt-5.4-mini` as of April 2026). In Pi, pass the equivalent on `subagent` via the `pi-subagents` extension. On platforms where the dispatch primitive has no model-override parameter or the available model names are unknown, omit the override — a working review on the parent model beats a broken dispatch on an unrecognized name. Check this on every Agent / `spawn_agent` / `subagent` call in the parallel dispatch; omitting it on Opus sessions silently 3-4x's the cost of a review.
 
+**Project-custom reviewers are exempt from the mid-tier override.** Do not pass a model override when dispatching a project-custom reviewer — honor whatever its own frontmatter `model:` declares (`inherit` runs it at the session model; an explicit tier runs it there). The built-in mid-tier default exists because each built-in persona's stakes were calibrated when this fork was authored; an unknown project reviewer's stakes cannot be, so the author who wrote it owns the cost/quality call. (Finance's `financial-modeling-reviewer` declares `model: inherit` precisely because a wrong retirement number is expensive.)
+
 **`design-intent-reviewer` — interrogation path and tools.** Its deepest intent source is attaching to the originating session and interrogating it (cc-explorer `convert_session` → `SendMessage`), which only works in an agent-teams context. When agent-teams is live, dispatch `design-intent-reviewer` so it can do this — as a **teammate, not a plain subagent**, since a plain dispatched subagent has no `SendMessage`. When agent-teams is off, it runs as an ordinary read-only reviewer over docs, tickets, commit messages, and chat-history reads — degraded, not broken. Unlike the other personas it declares **no `tools:` allowlist** (it inherits the available toolset — cc-explorer read tools, tracker access via `Bash`, and `SendMessage` when present — and stays read-only on the repo per the subagent template's read-only contract). The exact inherit-vs-allowlist and teammate-dispatch mechanics are harness-specific and worth validating per platform.
+
+**Project-custom reviewers — dispatch path.** Dispatch them the same way as a built-in persona, with one wrinkle: they live in the repo under review, not in this plugin. Where the harness auto-registers a project's `.claude/agents/` as subagent types (Claude Code does), dispatch by the agent's **bare** registered name — `financial-modeling-reviewer`, with no `engineering-loop:` plugin prefix — and pass the subagent template as the task prompt; the agent file is already the subagent's system prompt, so the persona need not be injected again. Where the harness has no project-agent registry, fall back to the portable path used for built-ins: read the agent file's body and inject it into the template's `{persona_file}` slot on a generic reviewer subagent. Either way the reviewer receives the same review-context bundle (items 2-6 above) and is bound by the same read-only contract.
 
 **Bounded parallel dispatch.** Respect the current harness's active-subagent limit. Queue selected reviewers, dispatch only as many as the harness accepts, and fill freed slots as reviewers complete. Treat active-agent/thread/concurrency-limit spawn errors as backpressure, not reviewer failure: leave the reviewer queued and retry after a slot frees. Record a reviewer as failed only after a successful dispatch times out/fails, or when dispatch fails for a non-capacity reason.
 

--- a/engineering-loop/skills/el-review/references/persona-catalog.md
+++ b/engineering-loop/skills/el-review/references/persona-catalog.md
@@ -50,10 +50,30 @@ Specialized analysis beyond what the persona agents cover. Spawn when the diff i
 |-------|-------|
 | `deployment-verification-agent` | Produces Go/No-Go deployment checklist with SQL verification queries, rollback procedures, and monitoring plans. **Unstructured output** (markdown runbook) — surfaced in Stage 6 Deployment Notes section, not the findings table. |
 
+## Project-custom conditional
+
+A fourth layer that lives **in the consuming project, not in engineering-loop**. A project with a domain reviewer too specific to ship in the general roster (a finance project's cash-flow-modeling lens, a game's determinism reviewer, a data team's schema-conventions reviewer) contributes it to its own review runs without modifying this plugin. The roster is extensible per-project; the reviewers stay where they belong.
+
+**Discovery.** The orchestrator globs the repo under review for `.claude/agents/*.md` and keeps only agents whose frontmatter sets `el-review: true`. The flag is the opt-in — most `.claude/agents/` entries are not review personas, so discovery is explicit, never automatic. Unmarked agents are ignored.
+
+**Selection.** Each opted-in agent's frontmatter `description` carries its own "invoke when…" criterion. The orchestrator treats it exactly like a built-in cross-cutting conditional's selection line: read the diff, decide whether the agent's stated domain is touched, select it when it is. Additive to the built-in layers, never a replacement.
+
+**Model.** Project-custom reviewers run at whatever their own frontmatter `model:` declares — they are exempt from the mid-tier dispatch override the built-ins receive. The built-in tiering was hand-calibrated per persona; an unknown project reviewer's stakes cannot be, so the author owns the call (`model: inherit` runs it at the session model).
+
+**Author contract.** A project-custom reviewer must conform to the same output contract as a built-in persona (see `subagent-template.md`):
+
+- Emit `findings-schema.json` JSON with a stable `reviewer` name (e.g. `financial-modeling`). Findings merge into the normal Stage 5 pipeline keyed by that name — no special surfacing.
+- Honor the anchored confidence rubric (anchors `0/25/50/75/100`; actionable floor `75`, P0 may surface at `50`).
+- Respect the `run_id` artifact convention: write full analysis to `/tmp/engineering-loop/review/{run_id}/{reviewer}.json`, return compact merge-tier JSON.
+- An agent that emits **unstructured** markdown instead can use the existing agent-native / deployment surfaces (Stage 6 dedicated sections); structured JSON is the path that flows through merge/dedup/confidence.
+
+**Reference implementation.** The King-family finance project's `financial-modeling-reviewer` (`~/projects/finance/.claude/agents/financial-modeling-reviewer.md`) is built to this contract — schema- and rubric-compatible, with an explicit "Invoke when…" description — and serves as the worked example for authors.
+
 ## Selection rules
 
 1. **Always spawn all always-on personas.**
 2. **For each cross-cutting conditional persona**, the orchestrator reads the diff and decides whether the persona's domain is relevant. This is a judgment call, not a keyword match.
 3. **For each stack-specific conditional persona**, use file extensions and changed patterns as a starting point, then decide whether the diff actually introduces meaningful work for that reviewer. Do not spawn language-specific reviewers just because one config or generated file happens to match the extension.
 4. **For the CE conditional agent**, spawn when the diff has destructive or risky data-layer changes (NOT NULL additions on populated tables, type changes that can lose precision, bulk backfills, irreversible DDL) and the operator wants an executable Go/No-Go runbook.
-5. **Announce the team** before spawning with a one-line justification per conditional reviewer selected.
+5. **For each project-custom reviewer** discovered via the `el-review: true` flag in the repo under review, judge its frontmatter `description` against the diff the same way as a cross-cutting conditional, and select it when its domain is touched.
+6. **Announce the team** before spawning with a one-line justification per conditional reviewer selected.


### PR DESCRIPTION
Closes #52.

## Problem

`el-review` spawned reviewers from a fixed built-in roster. A consuming project with a **domain-specific** reviewer had no way to contribute it — and when the orchestrator wanted that lens, it improvised a one-off `general-purpose` agent that never loaded the real persona and returned freeform prose outside the findings pipeline. Strictly worse than the reviewer the project already built.

Root cause: there was never an instruction telling the orchestrator to discover/select/route project-local reviewers.

## Change

A fourth, **per-project conditional layer** — the discovery mechanism is the feature; any project gets it:

1. **Discover** — glob the repo-under-review's `.claude/agents/*.md`, keep only agents whose frontmatter sets `el-review: true`. Explicit opt-in; unmarked agents are ignored.
2. **Select** — judge each opted-in agent's `description` ("invoke when…") against the diff, exactly like a built-in cross-cutting conditional. Additive, never a replacement.
3. **Dispatch** — through the standard subagent template (by bare auto-registered subagent type on Claude Code; by `{persona_file}` injection on harnesses without a project-agent registry). Structured findings merge through Stage 5 keyed by `reviewer` name; no special handling.

**Model:** project-custom reviewers are exempt from the mid-tier override — they honor their own frontmatter `model:`. Built-in tiering was hand-calibrated per persona; an unknown project reviewer's stakes can't be, so the author owns the call.

**Non-goal (respected):** project reviewers are NOT added to engineering-loop's `plugin.json agents[]` — they live in the consuming project.

## Files

- `skills/el-review/SKILL.md` — Stage 3 discovery/selection, Stage 4 dispatch + model-exemption notes, roster overview line
- `skills/el-review/references/persona-catalog.md` — 4th-layer section documenting discovery + the author contract
- `README.md`, `.claude-plugin/plugin.json` — advertise the capability; `v0.5.0 → v0.6.0`

## Verification

- Discovery filter verified deterministically against the reference consumer (the finance project's `financial-modeling-reviewer`, opted in via a one-line flag in that repo): the glob+frontmatter filter selects exactly the flagged agent; the new key parses as valid YAML and Claude Code ignores unknown agent-frontmatter keys.
- Full live `/el:review` end-to-end (orchestrator discovers → selects → dispatches the **real** agent, findings in the merged table) runs once this skill version is active — the installed plugin is still v0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)